### PR TITLE
Inactivate known external links when needed

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -9,6 +9,7 @@
 -->
 
 <script>
+import { shouldInactivateRef } from 'docc-render/utils/references';
 import AppStore from 'docc-render/stores/AppStore';
 import referencesProvider from 'docc-render/mixins/referencesProvider';
 import Aside from './ContentNode/Aside.vue';
@@ -471,11 +472,7 @@ function renderNode(createElement, context = {}) {
         || reference.titleInlineContent;
       const titlePlainText = node.overridingTitle || reference.title;
       const isActive = node.isActive ?? true;
-      const isInactive = !!(includedArchiveIdentifiers.length && (
-        !includedArchiveIdentifiers.some(id => (
-          node.identifier?.startsWith(`doc://${id}`)
-        ))
-      ));
+      const isInactive = shouldInactivateRef(node.identifier, { includedArchiveIdentifiers });
       return createElement(Reference, {
         props: {
           url: reference.url,

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -470,17 +470,18 @@ function renderNode(createElement, context = {}) {
       const titleInlineContent = node.overridingTitleInlineContent
         || reference.titleInlineContent;
       const titlePlainText = node.overridingTitle || reference.title;
-      const isInactive = includedArchiveIdentifiers.length && (
+      const isActive = node.isActive ?? true;
+      const isInactive = !!(includedArchiveIdentifiers.length && (
         !includedArchiveIdentifiers.some(id => (
           node.identifier?.startsWith(`doc://${id}`)
         ))
-      );
+      ));
       return createElement(Reference, {
         props: {
           url: reference.url,
           kind: reference.kind,
           role: reference.role,
-          isActive: node.isActive && !isInactive,
+          isActive: isActive && !isInactive,
           ideTitle: reference.ideTitle,
           titleStyle: reference.titleStyle,
           hasInlineFormatting: !!titleInlineContent,

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -9,6 +9,7 @@
 -->
 
 <script>
+import AppStore from 'docc-render/stores/AppStore';
 import referencesProvider from 'docc-render/mixins/referencesProvider';
 import Aside from './ContentNode/Aside.vue';
 import CodeListing from './ContentNode/CodeListing.vue';
@@ -118,9 +119,13 @@ const TabNavigatorVerticalThreshold = 7;
 // and any of its children by mapping each node `type` to a given Vue component
 //
 // Note: A plain string of text is returned for nodes with `type="text"`
-function renderNode(createElement, references) {
+function renderNode(createElement, context = {}) {
+  const {
+    includedArchiveIdentifiers = [],
+    references = {},
+  } = context;
   const renderChildren = children => children.map(
-    renderNode(createElement, references),
+    renderNode(createElement, context),
   );
 
   const renderListItems = items => items.map(item => (
@@ -460,17 +465,23 @@ function renderNode(createElement, references) {
         node.title
       ));
     case InlineType.reference: {
+      console.log(node.identifier, includedArchiveIdentifiers);
       const reference = references[node.identifier];
       if (!reference) return null;
       const titleInlineContent = node.overridingTitleInlineContent
         || reference.titleInlineContent;
       const titlePlainText = node.overridingTitle || reference.title;
+      const isInactive = includedArchiveIdentifiers.length && (
+        !includedArchiveIdentifiers.some(id => (
+          node.identifier?.startsWith(`doc://${id}`)
+        ))
+      );
       return createElement(Reference, {
         props: {
           url: reference.url,
           kind: reference.kind,
           role: reference.role,
-          isActive: node.isActive,
+          isActive: node.isActive && !isInactive,
           ideTitle: reference.ideTitle,
           titleStyle: reference.titleStyle,
           hasInlineFormatting: !!titleInlineContent,
@@ -521,11 +532,14 @@ export default {
   name: 'ContentNode',
   constants: { TableHeaderStyle, TableColumnAlignments },
   mixins: [referencesProvider],
+  data: () => ({
+    appState: AppStore.state,
+  }),
   render: function render(createElement) {
     // Dynamically map each content item and any children to their
     // corresponding components, and wrap the whole tree in a <div>
     return createElement(this.tag, { class: 'content' }, (
-      this.content.map(renderNode(createElement, this.references), this)
+      this.content.map(renderNode(createElement, this.context), this)
     ));
   },
   props: {
@@ -691,6 +705,14 @@ export default {
         return text;
       }, '').trim();
     },
+    includedArchiveIdentifiers: ({ appState }) => appState.includedArchiveIdentifiers,
+    context: ({
+      includedArchiveIdentifiers = [],
+      references = {},
+    }) => ({
+      includedArchiveIdentifiers,
+      references,
+    }),
   },
   BlockType,
   InlineType,

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -465,7 +465,6 @@ function renderNode(createElement, context = {}) {
         node.title
       ));
     case InlineType.reference: {
-      console.log(node.identifier, includedArchiveIdentifiers);
       const reference = references[node.identifier];
       if (!reference) return null;
       const titleInlineContent = node.overridingTitleInlineContent

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
@@ -10,16 +10,25 @@
 
 <script>
 // This component renders token text as a link to a given type.
+import { shouldInactivateRef } from 'docc-render/utils/references';
+import AppStore from 'docc-render/stores/AppStore';
 import Reference from 'docc-render/components/ContentNode/Reference.vue';
 import referencesProvider from 'docc-render/mixins/referencesProvider';
 
 export default {
   name: 'LinkableToken',
   mixins: [referencesProvider],
+  data: () => ({
+    appState: AppStore.state,
+  }),
   render(createElement) {
     const reference = this.references[this.identifier];
+
+    const { includedArchiveIdentifiers } = this;
+    const isInactive = shouldInactivateRef(this.identifier, { includedArchiveIdentifiers });
+
     // internal and external link
-    if (reference && reference.url) {
+    if (reference && reference.url && !isInactive) {
       return createElement(Reference, {
         props: {
           url: reference.url,
@@ -30,10 +39,13 @@ export default {
         this.$slots.default
       ));
     }
-    // unresolved link, use span tag
+    // unresolved/inactive link, use span tag
     return createElement('span', {}, (
       this.$slots.default
     ));
+  },
+  computed: {
+    includedArchiveIdentifiers: ({ appState }) => appState.includedArchiveIdentifiers,
   },
   props: {
     identifier: {

--- a/src/components/Navigator/NavigatorDataProvider.vue
+++ b/src/components/Navigator/NavigatorDataProvider.vue
@@ -11,6 +11,7 @@
 <script>
 import { fetchIndexPathsData } from 'docc-render/utils/data';
 import { flattenNestedData } from 'docc-render/utils/navigatorData';
+import AppStore from 'docc-render/stores/AppStore';
 import Language from 'docc-render/constants/Language';
 
 /**
@@ -88,11 +89,16 @@ export default {
     async fetchIndexData() {
       try {
         this.isFetching = true;
-        const { interfaceLanguages, references } = await fetchIndexPathsData(
+        const {
+          includedArchiveIdentifiers = [],
+          interfaceLanguages,
+          references,
+        } = await fetchIndexPathsData(
           { slug: this.$route.params.locale || '' },
         );
         this.navigationIndex = Object.freeze(interfaceLanguages);
         this.navigationReferences = Object.freeze(references);
+        AppStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);
       } catch (e) {
         this.errorFetching = true;
       } finally {

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -30,6 +30,7 @@ export default {
     supportsAutoColorScheme,
     systemColorScheme: ColorScheme.light,
     availableLocales: [],
+    includedArchiveIdentifiers: [],
   },
   reset() {
     this.state.imageLoadingStrategy = process.env.VUE_APP_TARGET === 'ide'
@@ -58,6 +59,9 @@ export default {
   },
   setSystemColorScheme(value) {
     this.state.systemColorScheme = value;
+  },
+  setIncludedArchiveIdentifiers(value) {
+    this.state.includedArchiveIdentifiers = value;
   },
   syncPreferredColorScheme() {
     if (!!Settings.preferredColorScheme

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -38,6 +38,7 @@ export default {
     this.state.preferredColorScheme = Settings.preferredColorScheme || defaultColorScheme;
     this.state.supportsAutoColorScheme = supportsAutoColorScheme;
     this.state.systemColorScheme = ColorScheme.light;
+    this.state.includedArchiveIdentifiers = [];
   },
   setImageLoadingStrategy(strategy) {
     this.state.imageLoadingStrategy = strategy;

--- a/src/stores/DocumentationTopicStore.js
+++ b/src/stores/DocumentationTopicStore.js
@@ -22,12 +22,10 @@ export default {
     ...changesState,
     ...pageSectionsState,
     references: {},
-    includedArchiveIdentifiers: [],
   },
   reset() {
     this.state.preferredLanguage = Settings.preferredLanguage;
     this.state.references = {};
-    this.state.includedArchiveIdentifiers = [];
     this.resetApiChanges();
   },
   setPreferredLanguage(language) {
@@ -39,9 +37,6 @@ export default {
   },
   setReferences(references) {
     this.state.references = references;
-  },
-  setIncludedArchiveIdentifiers(identifiers) {
-    this.state.includedArchiveIdentifiers = identifiers;
   },
   ...changesActions,
   ...pageSectionsActions,

--- a/src/stores/DocumentationTopicStore.js
+++ b/src/stores/DocumentationTopicStore.js
@@ -22,10 +22,12 @@ export default {
     ...changesState,
     ...pageSectionsState,
     references: {},
+    includedArchiveIdentifiers: [],
   },
   reset() {
     this.state.preferredLanguage = Settings.preferredLanguage;
     this.state.references = {};
+    this.state.includedArchiveIdentifiers = [];
     this.resetApiChanges();
   },
   setPreferredLanguage(language) {
@@ -37,6 +39,9 @@ export default {
   },
   setReferences(references) {
     this.state.references = references;
+  },
+  setIncludedArchiveIdentifiers(identifiers) {
+    this.state.includedArchiveIdentifiers = identifiers;
   },
   ...changesActions,
   ...pageSectionsActions,

--- a/src/utils/references.js
+++ b/src/utils/references.js
@@ -1,0 +1,19 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2024 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+// eslint-disable-next-line import/prefer-default-export
+export function shouldInactivateRef(identifier, context = {}) {
+  const { includedArchiveIdentifiers = [] } = context;
+  return !!(includedArchiveIdentifiers.length && (
+    !includedArchiveIdentifiers.some(id => (
+      identifier?.startsWith(`doc://${id}`)
+    ))
+  ));
+}

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -1297,6 +1297,57 @@ describe('ContentNode', () => {
       const reference = wrapper.find('.content');
       expect(reference.isEmpty()).toBe(true);
     });
+
+    it('inactivates references when `includedArchiveIdentifiers` is present and does not include the identifier', () => {
+      const id = {
+        bar: 'doc://Foo/documentation/foo/bar',
+        baz: 'doc://Baz/documentation/baz',
+      };
+      const wrapper = mountWithItem({
+        type: 'reference',
+        identifier: id.bar,
+      }, {
+        [id.bar]: {
+          title: 'bar',
+          url: '/documentation/foo/bar',
+        },
+      });
+
+      // active by default
+      let reference = wrapper.find(Reference);
+      expect(reference.exists()).toBe(true);
+      expect(reference.props('isActive')).toBe(true);
+
+      // inactive when `includedArchiveIdentifiers` is non-empty and does not include this id
+      wrapper.setData({
+        appState: {
+          includedArchiveIdentifiers: ['Baz'],
+        },
+      });
+      reference = wrapper.find(Reference);
+      expect(reference.exists()).toBe(true);
+      expect(reference.props('isActive')).toBe(false);
+
+      // active when `includedArchiveIdentifiers` is non-empty and includes this id
+      wrapper.setData({
+        appState: {
+          includedArchiveIdentifiers: ['Baz', 'Foo'],
+        },
+      });
+      reference = wrapper.find(Reference);
+      expect(reference.exists()).toBe(true);
+      expect(reference.props('isActive')).toBe(true);
+
+      // still active when `includedArchiveIdentifiers` is empty (for backwards compatibility)
+      wrapper.setData({
+        appState: {
+          includedArchiveIdentifiers: [],
+        },
+      });
+      reference = wrapper.find(Reference);
+      expect(reference.exists()).toBe(true);
+      expect(reference.props('isActive')).toBe(true);
+    });
   });
 
   describe('with type="strong"', () => {

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.spec.js
@@ -70,4 +70,49 @@ describe('LinkableToken', () => {
     expect(link.props('url')).toBe(foo.url);
     expect(link.text()).toBe(foo.title);
   });
+
+  it('renders a span for inactive references', () => {
+    const bar = {
+      identifier: 'doc://Foo/documentation/foo/bar',
+      title: 'Bar',
+      url: '/documentation/foo/bar',
+    };
+    const references = { [bar.identifier]: bar };
+    const wrapper = shallowMount(LinkableToken, {
+      propsData: { identifier: bar.identifier },
+      slots: { default: bar.title },
+      provide: {
+        store: {
+          state: { references },
+        },
+      },
+    });
+
+    // active by default
+    let reference = wrapper.find(Reference);
+    expect(reference.exists()).toBe(true);
+    expect(reference.props('url')).toBe(bar.url);
+    expect(reference.text()).toBe(bar.title);
+
+    // inactive when `includedArchiveIdentifiers` is non-empty and does not include id
+    wrapper.setData({
+      appState: {
+        includedArchiveIdentifiers: ['Baz'],
+      },
+    });
+    reference = wrapper.find(Reference);
+    expect(reference.exists()).toBe(false);
+    expect(wrapper.text()).toBe(bar.title);
+
+    // active when `includedArchiveIdentifiers` is non-empty and includes id
+    wrapper.setData({
+      appState: {
+        includedArchiveIdentifiers: ['Baz', 'Foo'],
+      },
+    });
+    reference = wrapper.find(Reference);
+    expect(reference.exists()).toBe(true);
+    expect(reference.props('url')).toBe(bar.url);
+    expect(reference.text()).toBe(bar.title);
+  });
 });

--- a/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
+++ b/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
@@ -10,6 +10,7 @@
 
 import NavigatorDataProvider from '@/components/Navigator/NavigatorDataProvider.vue';
 import { shallowMount } from '@vue/test-utils';
+import AppStore from 'docc-render/stores/AppStore';
 import Language from 'docc-render/constants/Language';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { fetchIndexPathsData } from '@/utils/data';
@@ -127,7 +128,13 @@ const references = {
   foo: { bar: 'bar' },
 };
 
+const includedArchiveIdentifiers = [
+  'doc://foo',
+  'doc://bar',
+];
+
 const response = {
+  includedArchiveIdentifiers,
   interfaceLanguages: {
     [Language.swift.key.url]: [
       swiftIndexOne,
@@ -172,6 +179,10 @@ const createWrapper = ({ propsData, ...others } = {}) => shallowMount(NavigatorD
 describe('NavigatorDataProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    AppStore.reset();
   });
 
   it('fetches data when mounting NavigatorDataProvider', async () => {
@@ -551,5 +562,13 @@ describe('NavigatorDataProvider', () => {
         uid: -827353283,
       },
     ]);
+  });
+
+  it('sets `includedArchiveIdentifiers` state in the app store', async () => {
+    expect(AppStore.state.includedArchiveIdentifiers).toEqual([]);
+    fetchIndexPathsData.mockResolvedValue(response);
+    createWrapper();
+    await flushPromises();
+    expect(AppStore.state.includedArchiveIdentifiers).toEqual(includedArchiveIdentifiers);
   });
 });

--- a/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
+++ b/tests/unit/components/Navigator/NavigatorDataProvider.spec.js
@@ -129,8 +129,8 @@ const references = {
 };
 
 const includedArchiveIdentifiers = [
-  'doc://foo',
-  'doc://bar',
+  'foo',
+  'bar',
 ];
 
 const response = {

--- a/tests/unit/stores/AppStore.spec.js
+++ b/tests/unit/stores/AppStore.spec.js
@@ -22,6 +22,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
   });
 
@@ -37,6 +38,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
 
     // restore target
@@ -72,11 +74,20 @@ describe('AppStore', () => {
     });
   });
 
+  describe('setIncludedArchiveIdentifiers', () => {
+    it('sets the included archive identifiers', () => {
+      const includedArchiveIdentifiers = ['doc://foo', 'doc://bar'];
+      AppStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);
+      expect(AppStore.state.includedArchiveIdentifiers).toEqual(includedArchiveIdentifiers);
+    });
+  });
+
   it('resets the state', () => {
     AppStore.setImageLoadingStrategy(ImageLoadingStrategy.eager);
     AppStore.setPreferredColorScheme(ColorScheme.auto);
     AppStore.setSystemColorScheme(ColorScheme.dark);
     AppStore.syncPreferredColorScheme();
+    AppStore.setIncludedArchiveIdentifiers(['a']);
     AppStore.reset();
 
     expect(AppStore.state).toEqual({
@@ -86,6 +97,7 @@ describe('AppStore', () => {
       systemColorScheme: ColorScheme.light,
       preferredLocale: null,
       availableLocales: [],
+      includedArchiveIdentifiers: [],
     });
   });
 });

--- a/tests/unit/stores/AppStore.spec.js
+++ b/tests/unit/stores/AppStore.spec.js
@@ -76,7 +76,7 @@ describe('AppStore', () => {
 
   describe('setIncludedArchiveIdentifiers', () => {
     it('sets the included archive identifiers', () => {
-      const includedArchiveIdentifiers = ['doc://foo', 'doc://bar'];
+      const includedArchiveIdentifiers = ['foo', 'bar'];
       AppStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);
       expect(AppStore.state.includedArchiveIdentifiers).toEqual(includedArchiveIdentifiers);
     });

--- a/tests/unit/utils/references.spec.js
+++ b/tests/unit/utils/references.spec.js
@@ -26,7 +26,7 @@ describe('shouldInactivateRef', () => {
     expect(shouldInactivateRef(refId, { includedArchiveIdentifiers: [] })).toBe(false);
   });
 
-  it('returns false when non-empy `includedArchiveIdentifiers` context includes id', () => {
+  it('returns false when non-empty `includedArchiveIdentifiers` context includes id', () => {
     expect(shouldInactivateRef(refId, {
       includedArchiveIdentifiers: [archiveIds.Foo],
     })).toBe(false);

--- a/tests/unit/utils/references.spec.js
+++ b/tests/unit/utils/references.spec.js
@@ -1,0 +1,52 @@
+/**
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2024 Apple Inc. and the Swift project authors
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+import { shouldInactivateRef } from 'docc-render/utils/references';
+
+const refId = 'doc://Foo/documentation/foo/bar';
+const archiveIds = {
+  Foo: 'Foo',
+  Bar: 'Bar',
+  Qux: 'Qux',
+};
+
+describe('shouldInactivateRef', () => {
+  it('returns false with no context', () => {
+    expect(shouldInactivateRef(refId)).toBe(false);
+    expect(shouldInactivateRef(refId, {})).toBe(false);
+  });
+
+  it('returns false when `includedArchiveIdentifiers` context is empty', () => {
+    expect(shouldInactivateRef(refId, { includedArchiveIdentifiers: [] })).toBe(false);
+  });
+
+  it('returns false when non-empy `includedArchiveIdentifiers` context includes id', () => {
+    expect(shouldInactivateRef(refId, {
+      includedArchiveIdentifiers: [archiveIds.Foo],
+    })).toBe(false);
+    expect(shouldInactivateRef(refId, {
+      includedArchiveIdentifiers: [
+        archiveIds.Bar,
+        archiveIds.Foo,
+      ],
+    })).toBe(false);
+  });
+
+  it('returns true when non-empty `includedArchiveIdentifiers` context does not include id', () => {
+    expect(shouldInactivateRef(refId, {
+      includedArchiveIdentifiers: [archiveIds.Bar],
+    })).toBe(true);
+    expect(shouldInactivateRef(refId, {
+      includedArchiveIdentifiers: [
+        archiveIds.Bar,
+        archiveIds.Qux,
+      ],
+    })).toBe(true);
+  });
+});


### PR DESCRIPTION
Bug/issue #, if applicable: 118834404

## Summary

This adds logic to inactivate links to pages from other targets unless they have been included in the same combined archive.

## Dependencies

https://github.com/apple/swift-docc-plugin/pull/84

## Testing

You can use the archives from this fixture for the convenience of testing purposes:
[archives.zip](https://github.com/user-attachments/files/15996968/archives.zip)

Steps:
1. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/Combined\ ExternalLinks\ Documentation.doccarchive npm run serve` and open http://localhost:8080/documentation/outer/outerclass/dosomething(with:)
2. Verify that all the links to "Inner" pages work, including in the declaration
3. Run `VUE_APP_DEV_SERVER_PROXY=/path/to/Outer.doccarchive npm run serve` and open http://localhost:8080/documentation/outer/outerclass/dosomething(with:)
4. Verify that all the links to "Inner" pages are no longer linked
5. Check for any other regressions with links and linked declaration types using other fixture content.

Known issues:
Due to the way that the Render JSON and Navigator JSON are loaded independently by the renderer, it's possible that the links in step 4 may be initially linked for a very brief moment until the navigator has finished loading. I've discussed this with @d-ronnqvist, and this limitation is acceptable for now given the way that things are structured.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
