### PR TITLE
[6.0] Fix regression where external links are rendering as plaintext

### DIFF
--- a/src/mixins/referencesProvider.js
+++ b/src/mixins/referencesProvider.js
@@ -9,6 +9,8 @@
 */
 import AppStore from 'docc-render/stores/AppStore';
 
+const TopicReferenceType = 'topic';
+
 export default {
   // inject the `store`
   inject: {
@@ -32,14 +34,18 @@ export default {
           state: { references: originalRefs = {} },
         },
       } = this;
-      // strip the `url` key from refs if their identifier comes from an
+      // strip the `url` key from "topic" refs if their identifier comes from an
       // archive that hasn't been included by DocC
       return Object.keys(originalRefs).reduce((newRefs, id) => {
-        const { url, ...refWithoutUrl } = originalRefs[id];
-        return {
+        const originalRef = originalRefs[id];
+        const { url, ...refWithoutUrl } = originalRef;
+        return originalRef.type === TopicReferenceType ? ({
           ...newRefs,
           [id]: isFromIncludedArchive(id) ? originalRefs[id] : refWithoutUrl,
-        };
+        }) : ({
+          ...newRefs,
+          [id]: originalRef,
+        });
       }, {});
     },
   },

--- a/src/mixins/referencesProvider.js
+++ b/src/mixins/referencesProvider.js
@@ -9,7 +9,10 @@
 */
 import AppStore from 'docc-render/stores/AppStore';
 
-const TopicReferenceType = 'topic';
+const TopicReferenceTypes = new Set([
+  'section',
+  'topic',
+]);
 
 export default {
   // inject the `store`
@@ -34,12 +37,12 @@ export default {
           state: { references: originalRefs = {} },
         },
       } = this;
-      // strip the `url` key from "topic" refs if their identifier comes from an
-      // archive that hasn't been included by DocC
+      // strip the `url` key from "topic"/"section" refs if their identifier
+      // comes from an archive that hasn't been included by DocC
       return Object.keys(originalRefs).reduce((newRefs, id) => {
         const originalRef = originalRefs[id];
         const { url, ...refWithoutUrl } = originalRef;
-        return originalRef.type === TopicReferenceType ? ({
+        return TopicReferenceTypes.has(originalRef.type) ? ({
           ...newRefs,
           [id]: isFromIncludedArchive(id) ? originalRefs[id] : refWithoutUrl,
         }) : ({

--- a/tests/unit/mixins/referencesProvider.spec.js
+++ b/tests/unit/mixins/referencesProvider.spec.js
@@ -50,9 +50,9 @@ const bb = {
 };
 const bbb = {
   identifier: 'doc://BB/documentation/BB/b',
-  url: '/documentation/BB/b',
+  url: '/documentation/BB/b#b',
   title: 'BB.B',
-  type: 'topic',
+  type: 'section',
 };
 
 const references = {

--- a/tests/unit/mixins/referencesProvider.spec.js
+++ b/tests/unit/mixins/referencesProvider.spec.js
@@ -34,21 +34,25 @@ const aa = {
   identifier: 'doc://A/documentation/A/a',
   url: '/documentation/A/a',
   title: 'A.A',
+  type: 'topic',
 };
 const ab = {
   identifier: 'doc://A/documentation/A/b',
   url: '/documentation/A/b',
   title: 'A.B',
+  type: 'topic',
 };
 const bb = {
   identifier: 'doc://B/documentation/B/b',
   url: '/documentation/B/b',
   title: 'B.B',
+  type: 'topic',
 };
 const bbb = {
   identifier: 'doc://BB/documentation/BB/b',
   url: '/documentation/BB/b',
   title: 'BB.B',
+  type: 'topic',
 };
 
 const references = {

--- a/tests/unit/mixins/referencesProvider.spec.js
+++ b/tests/unit/mixins/referencesProvider.spec.js
@@ -54,12 +54,19 @@ const bbb = {
   title: 'BB.B',
   type: 'section',
 };
+const c = {
+  identifier: 'https://abc.dev',
+  url: 'https://abc.dev',
+  title: 'C',
+  type: 'link',
+};
 
 const references = {
   [aa.identifier]: aa,
   [ab.identifier]: ab,
   [bb.identifier]: bb,
   [bbb.identifier]: bbb,
+  [c.identifier]: c,
 };
 
 const provide = {
@@ -121,5 +128,6 @@ describe('referencesProvider', () => {
     expect(refs3[bb.identifier].url).toBe(bb.url); // bb still has `url`
     expect(refs3[bbb.identifier].title).toBe(bbb.title);
     expect(refs3[bbb.identifier].url).toBeFalsy(); // bbb `url` is gone now
+    expect(refs3[c.identifier].url).toBe(c.url); // external link untouched
   });
 });


### PR DESCRIPTION
- **Explanation:** Fixes regression where external links render as plaintext
- **Scope:** Impacts pages with links to external sources
- **Issue:** rdar://133444687
- **Risk:** Low, focused change to make JS logic more strict when stripping link data
- **Testing:** Updated unit tests, manually tested pages with internal and external link content, verified that known external links are still purposefully rendered as plaintext in the scenario from #878
- **Reviewer:** @hqhhuang 
- **Original PR:** #886 