### PR TITLE
Use bash for scripts instead of sh

### DIFF
--- a/bin/build-docs
+++ b/bin/build-docs
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # This source file is part of the Swift.org open source project
 #

--- a/bin/rundocc
+++ b/bin/rundocc
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 function rundocc() {
   if command -v xcrun >/dev/null 2>&1; then

--- a/bin/serve-docs
+++ b/bin/serve-docs
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # This source file is part of the Swift.org open source project
 #


### PR DESCRIPTION
Bug/issue #, if applicable: 

## Summary

This fixes a minor issue with some scripts in `bin/` that use the shebang line `#!/usr/bin/env sh`.

When running on a system with an actual `sh` implementation, these scripts fail due to a syntax issue with the `function` keyword (apparently a `bash` specific thing). This is easy to miss on platforms where `sh` is just a link to `bash`, so using `bash` will ensure that the scripts work without changes on all platforms.

## Testing

Steps:
1. Run `npm run docs` to exercise all these scripts and ensure they are still functional.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
