### PR TITLE
Inactivate known external links (Re-implementation)

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -467,6 +467,8 @@ function renderNode(createElement, references) {
       const titlePlainText = node.overridingTitle || reference.title;
       return createElement(Reference, {
         props: {
+          identifier: node.identifier,
+          type: reference.type,
           url: reference.url,
           kind: reference.kind,
           role: reference.role,

--- a/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/DeclarationToken/LinkableToken.vue
@@ -22,6 +22,8 @@ export default {
     if (reference && reference.url) {
       return createElement(Reference, {
         props: {
+          identifier: this.identifier,
+          type: reference.type,
           url: reference.url,
           kind: reference.kind,
           role: reference.role,

--- a/src/components/DocumentationTopic/Relationships.vue
+++ b/src/components/DocumentationTopic/Relationships.vue
@@ -57,7 +57,10 @@ export default {
         ...section,
         symbols: section.identifiers.reduce((list, id) => (
           this.references[id] ? (
-            list.concat(this.references[id])
+            list.concat({
+              ...this.references[id],
+              identifier: id,
+            })
           ) : (
             list
           )

--- a/src/components/DocumentationTopic/RelationshipsList.vue
+++ b/src/components/DocumentationTopic/RelationshipsList.vue
@@ -21,6 +21,8 @@
         :role="symbol.role"
         :kind="symbol.kind"
         :url="symbol.url"
+        :identifier="symbol.identifier"
+        :type="symbol.type"
       >{{symbol.title}}</Reference>
       <WordBreak v-else tag="code">{{symbol.title}}</WordBreak>
       <ConditionalConstraints

--- a/src/mixins/referencesProvider.js
+++ b/src/mixins/referencesProvider.js
@@ -9,11 +9,6 @@
 */
 import AppStore from 'docc-render/stores/AppStore';
 
-const TopicReferenceTypes = new Set([
-  'section',
-  'topic',
-]);
-
 export default {
   // inject the `store`
   inject: {
@@ -30,40 +25,6 @@ export default {
   data: () => ({ appState: AppStore.state }),
   computed: {
     // exposes the references for the current page
-    references() {
-      const {
-        isFromIncludedArchive,
-        store: {
-          state: { references: originalRefs = {} },
-        },
-      } = this;
-      // strip the `url` key from "topic"/"section" refs if their identifier
-      // comes from an archive that hasn't been included by DocC
-      return Object.keys(originalRefs).reduce((newRefs, id) => {
-        const originalRef = originalRefs[id];
-        const { url, ...refWithoutUrl } = originalRef;
-        return TopicReferenceTypes.has(originalRef.type) ? ({
-          ...newRefs,
-          [id]: isFromIncludedArchive(id) ? originalRefs[id] : refWithoutUrl,
-        }) : ({
-          ...newRefs,
-          [id]: originalRef,
-        });
-      }, {});
-    },
-  },
-  methods: {
-    isFromIncludedArchive(id) {
-      const { includedArchiveIdentifiers = [] } = this.appState;
-      // for backwards compatibility purposes, treat all references as being
-      // from included archives if there is no data for it
-      if (!includedArchiveIdentifiers.length) {
-        return true;
-      }
-
-      return includedArchiveIdentifiers.some(archiveId => (
-        id?.startsWith(`doc://${archiveId}/`)
-      ));
-    },
+    references: ({ store }) => store.state.references,
   },
 };

--- a/tests/unit/components/ContentNode/Reference.spec.js
+++ b/tests/unit/components/ContentNode/Reference.spec.js
@@ -278,4 +278,84 @@ describe('Reference', () => {
     expect(ref.props('url')).toBe('/downloads/foo.zip');
     expect(ref.text()).toBe('Foo');
   });
+
+  it('inactivates refs as appropriate with non-empty `includedArchiveIdentifiers`', () => {
+    const createWrapper = propsData => shallowMount(Reference, {
+      localVue,
+      router,
+      propsData,
+      slots: { default: propsData.title },
+    });
+    const aa = createWrapper({
+      identifier: 'doc://A/documentation/A/a',
+      url: '/documentation/A/a',
+      title: 'A.A',
+      type: 'topic',
+    });
+    const ab = createWrapper({
+      identifier: 'doc://A/documentation/A/b',
+      url: '/documentation/A/b',
+      title: 'A.B',
+      type: 'topic',
+    });
+    const bb = createWrapper({
+      identifier: 'doc://B/documentation/B/b',
+      url: '/documentation/B/b',
+      title: 'B.B',
+      type: 'topic',
+    });
+    const bbb = createWrapper({
+      identifier: 'doc://BB/documentation/BB/b',
+      url: '/documentation/BB/b#b',
+      title: 'BB.B',
+      type: 'section',
+    });
+    const c = createWrapper({
+      identifier: 'https://abc.dev',
+      url: 'https://abc.dev',
+      title: 'C',
+      type: 'link',
+    });
+
+    expect(aa.find(ReferenceInternal).props('isActive')).toBe(true);
+    expect(ab.find(ReferenceInternal).props('isActive')).toBe(true);
+    expect(bb.find(ReferenceInternal).props('isActive')).toBe(true);
+    expect(bbb.find(ReferenceInternal).props('isActive')).toBe(true);
+    expect(c.find(ReferenceExternal).props('isActive')).toBe(true);
+
+    const allIncluded = {
+      appState: {
+        includedArchiveIdentifiers: ['A', 'B', 'BB'],
+      },
+    };
+    aa.setData(allIncluded);
+    expect(aa.find(ReferenceInternal).props('isActive')).toBe(true);
+    ab.setData(allIncluded);
+    expect(ab.find(ReferenceInternal).props('isActive')).toBe(true);
+    bb.setData(allIncluded);
+    expect(bb.find(ReferenceInternal).props('isActive')).toBe(true);
+    bbb.setData(allIncluded);
+    expect(bbb.find(ReferenceInternal).props('isActive')).toBe(true);
+    c.setData(allIncluded);
+    expect(c.find(ReferenceExternal).props('isActive')).toBe(true);
+
+    // with only the B archive included, only internal links within B should
+    // be active (only bb in this example)
+    // c is an external link so it will also remain active
+    const onlyB = {
+      appState: {
+        includedArchiveIdentifiers: ['B'],
+      },
+    };
+    aa.setData(onlyB);
+    expect(aa.find(ReferenceInternal).props('isActive')).toBe(false);
+    ab.setData(onlyB);
+    expect(ab.find(ReferenceInternal).props('isActive')).toBe(false);
+    bb.setData(onlyB);
+    expect(bb.find(ReferenceInternal).props('isActive')).toBe(true);
+    bbb.setData(onlyB);
+    expect(bbb.find(ReferenceInternal).props('isActive')).toBe(false);
+    c.setData(onlyB);
+    expect(c.find(ReferenceExternal).props('isActive')).toBe(true);
+  });
 });

--- a/tests/unit/mixins/referencesProvider.spec.js
+++ b/tests/unit/mixins/referencesProvider.spec.js
@@ -91,43 +91,4 @@ describe('referencesProvider', () => {
     expect(inner.exists()).toBe(true);
     expect(inner.props('references')).toEqual(references);
   });
-
-  it('removes `url` data for refs with non-empty `includedArchiveIdentifiers` app state', () => {
-    // empty `includedArchiveIdentifiers` — no changes to refs
-    const outer = createOuter();
-    let inner = outer.find(FakeComponentInner);
-    expect(inner.exists()).toBe(true);
-    expect(inner.props('references')).toEqual(references);
-
-    // `includedArchiveIdentifiers` contains all refs - no changes to refs
-    outer.setData({
-      appState: {
-        includedArchiveIdentifiers: ['A', 'B', 'BB'],
-      },
-    });
-    inner = outer.find(FakeComponentInner);
-    expect(inner.exists()).toBe(true);
-    expect(inner.props('references')).toEqual(references);
-
-    // `includedArchiveIdentifiers` only contains archive B — remove `url` field
-    // from all non-B refs
-    outer.setData({
-      appState: {
-        includedArchiveIdentifiers: ['B'],
-      },
-    });
-    inner = outer.find(FakeComponentInner);
-    expect(inner.exists()).toBe(true);
-    const refs3 = inner.props('references');
-    expect(refs3).not.toEqual(references);
-    expect(refs3[aa.identifier].title).toBe(aa.title);
-    expect(refs3[aa.identifier].url).toBeFalsy(); // aa `url` is gone now
-    expect(refs3[ab.identifier].title).toBe(ab.title);
-    expect(refs3[ab.identifier].url).toBeFalsy(); // ab `url` is gone now
-    expect(refs3[bb.identifier].title).toBe(bb.title);
-    expect(refs3[bb.identifier].url).toBe(bb.url); // bb still has `url`
-    expect(refs3[bbb.identifier].title).toBe(bbb.title);
-    expect(refs3[bbb.identifier].url).toBeFalsy(); // bbb `url` is gone now
-    expect(refs3[c.identifier].url).toBe(c.url); // external link untouched
-  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 136247329 (#894)

## Summary

This PR re-implements #878 in a way that has a less noticeable performance impact on the initial page load experience. Instead of stripping out `url` data from the top-level `references` object, each individual `Reference` component will dynamically check for its "active-ness" as the index data is loaded.

The advantage to this new approach is that it will have a smaller impact on the initial access of `references`, which can be fairly noticeable for pages with huge numbers of links. (See #894 for an example)

One drawback to this new approach is that the links will start out as clickable links and quickly flash to non-linked text since this check will now happen dynamically when the index is loaded instead of before all references are available. I discussed this offline with @d-ronnqvist, and he believes that this is an acceptable tradeoff.

## Testing

Steps:
1. Follow testing instructions from #878 and verify that the behavior there still works as expected.
2. Verify that the performance issue observed in #894 is mitigated.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
