### PR TITLE
Ensure dark colors are always used in tutorials overview hero

### DIFF
--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -121,6 +121,18 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .tutorials-overview {
+  @media screen {
+    // ensure dark colors are always used, regardless of the selected
+    // light/dark/auto color scheme preference
+    //
+    // unfortunately the order of the property declaration matters here due
+    // to the way that some properties refer to others, which is why both the
+    // light and the dark vars are included here, even though the dark ones
+    // override the light ones...
+    @include color-vars-light;
+    @include color-vars-dark;
+  }
+
   background: dark-color(fill);
   flex: 1;
   height: 100%;
@@ -143,20 +155,6 @@ export default {
     .radial-gradient {
       background: #111111 !important;
     }
-  }
-}
-
-.theme-dark {
-  @media screen {
-    // ensure dark colors are always used, regardless of the selected
-    // light/dark/auto color scheme preference
-    //
-    // unfortunately the order of the property declaration matters here due
-    // to the way that some properties refer to others, which is why both the
-    // light and the dark vars are included here, even though the dark ones
-    // override the light ones...
-    @include color-vars-light;
-    @include color-vars-dark;
   }
 }
 </style>

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <div class="tutorials-overview">
+  <div class="tutorials-overview theme-dark">
     <Nav
       v-if="!isTargetIDE"
       :sections="otherSections"
@@ -143,6 +143,20 @@ export default {
     .radial-gradient {
       background: #111111 !important;
     }
+  }
+}
+
+.theme-dark {
+  @media screen {
+    // ensure dark colors are always used, regardless of the selected
+    // light/dark/auto color scheme preference
+    //
+    // unfortunately the order of the property declaration matters here due
+    // to the way that some properties refer to others, which is why both the
+    // light and the dark vars are included here, even though the dark ones
+    // override the light ones...
+    @include color-vars-light;
+    @include color-vars-dark;
   }
 }
 </style>

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -9,7 +9,7 @@
 -->
 
 <template>
-  <div class="tutorials-overview theme-dark">
+  <div class="tutorials-overview">
     <Nav
       v-if="!isTargetIDE"
       :sections="otherSections"
@@ -121,18 +121,6 @@ export default {
 @import 'docc-render/styles/_core.scss';
 
 .tutorials-overview {
-  @media screen {
-    // ensure dark colors are always used, regardless of the selected
-    // light/dark/auto color scheme preference
-    //
-    // unfortunately the order of the property declaration matters here due
-    // to the way that some properties refer to others, which is why both the
-    // light and the dark vars are included here, even though the dark ones
-    // override the light ones...
-    @include color-vars-light;
-    @include color-vars-dark;
-  }
-
   background: dark-color(fill);
   flex: 1;
   height: 100%;

--- a/src/components/TutorialsOverview/Hero.vue
+++ b/src/components/TutorialsOverview/Hero.vue
@@ -75,6 +75,19 @@ export default {
 
 .hero {
   @include breakpoint-content;
+
+  @media screen {
+    // ensure dark colors are always used, regardless of the selected
+    // light/dark/auto color scheme preference
+    //
+    // unfortunately the order of the property declaration matters here due
+    // to the way that some properties refer to others, which is why both the
+    // light and the dark vars are included here, even though the dark ones
+    // override the light ones...
+    @include color-vars-light;
+    @include color-vars-dark;
+  }
+
   padding-bottom: rem(80px);
   padding-top: rem(80px);
 }


### PR DESCRIPTION
Bug/issue #, if applicable: 137430837

## Summary

Fixes an issue where certain colors may look off when viewing a tutorials overview page with a light system/user appearance.

This problem/solution is very similar to #760, just in a different "always dark" component.

## Testing

Steps:
1. Add some aside content to a tutorial overview page and view it in light mode

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS-only changes)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
