### PR TITLE
Support min/max length data in "Attributes" section

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/ParameterAttributes.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/ParameterAttributes.vue
@@ -38,6 +38,15 @@
       </template>
     </ParameterMetaAttribute>
     <ParameterMetaAttribute
+      v-if="shouldRender(AttributeKind.minimumLength)"
+      v-bind="{ kind: AttributeKind.minimumLength, attributes: attributesObject, changes }">
+      <template v-slot="{ attribute }">
+        {{ $t('formats.colon', {
+          content: attribute.title || $t('parameters.minimumLength')
+        }) }}<code>{{ attribute.value }}</code>
+      </template>
+    </ParameterMetaAttribute>
+    <ParameterMetaAttribute
       v-if="shouldRender(AttributeKind.maximum)"
       v-bind="{ kind: AttributeKind.maximum, attributes: attributesObject, changes }">
       <template v-slot="{ attribute }">
@@ -53,6 +62,15 @@
         {{ $t('formats.colon', {
           content: attribute.title || $t('parameters.maximum')
         }) }}<code>&lt; {{ attribute.value }}</code>
+      </template>
+    </ParameterMetaAttribute>
+    <ParameterMetaAttribute
+      v-if="shouldRender(AttributeKind.maximumLength)"
+      v-bind="{ kind: AttributeKind.maximumLength, attributes: attributesObject, changes }">
+      <template v-slot="{ attribute }">
+        {{ $t('formats.colon', {
+          content: attribute.title || $t('parameters.maximumLength')
+        }) }}<code>{{ attribute.value }}</code>
       </template>
     </ParameterMetaAttribute>
     <ParameterMetaAttribute
@@ -94,8 +112,10 @@ const AttributeKind = {
   default: 'default',
   maximum: 'maximum',
   maximumExclusive: 'maximumExclusive',
+  maximumLength: 'maximumLength',
   minimum: 'minimum',
   minimumExclusive: 'minimumExclusive',
+  minimumLength: 'minimumLength',
 };
 
 /**

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -172,9 +172,9 @@
   "parameters": {
     "default": "Default",
     "minimum": "Minimum",
-    "minimumLength": "Minimum Length",
+    "minimumLength": "Minimum length",
     "maximum": "Maximum",
-    "maximumLength": "Maximum Length",
+    "maximumLength": "Maximum length",
     "possible-types": "Type | Possible types",
     "possible-values": "Value | Possible Values"
   },

--- a/src/lang/locales/en-US.json
+++ b/src/lang/locales/en-US.json
@@ -172,7 +172,9 @@
   "parameters": {
     "default": "Default",
     "minimum": "Minimum",
+    "minimumLength": "Minimum Length",
     "maximum": "Maximum",
+    "maximumLength": "Maximum Length",
     "possible-types": "Type | Possible types",
     "possible-values": "Value | Possible Values"
   },

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/ParameterAttributes.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/ParameterAttributes.spec.js
@@ -19,6 +19,8 @@ const { ParameterMetaAttribute } = ParameterAttributes.components;
 const defaultMetadata = { kind: AttributeKind.default, value: 3, title: 'Default' };
 const minimumMetadata = { kind: AttributeKind.minimum, value: 20, title: 'Minimum Value' };
 const maximumMetadata = { kind: AttributeKind.maximum, value: 50, title: 'Maximum Length' };
+const minimumLengthMetadata = { kind: AttributeKind.minimumLength, value: 1, title: 'Minimum Length' };
+const maximumLengthMetadata = { kind: AttributeKind.maximumLength, value: 10, title: 'Maximum Length' };
 const minimumExclusiveMetadata = { kind: AttributeKind.minimumExclusive, value: 2, title: 'Minimum' };
 const maximumExclusiveMetadata = { kind: AttributeKind.maximumExclusive, value: 5, title: 'Maximum' };
 const allowedValuesMetadata = {
@@ -88,6 +90,18 @@ describe('ParameterAttributes', () => {
         .at(1)
         .text(),
     ).toBe('formats.colon Maximum< 5');
+  });
+
+  it('displays min/max length metadata', () => {
+    const wrapper = mountComponent({
+      attributes: [
+        minimumLengthMetadata,
+        maximumLengthMetadata,
+      ],
+    });
+    const metadata = wrapper.findAll('.property-metadata');
+    expect(metadata.at(0).text()).toBe('formats.colon Minimum Length1');
+    expect(metadata.at(1).text()).toBe('formats.colon Maximum Length10');
   });
 
   it('displays possible types/values metadata', () => {


### PR DESCRIPTION
Bug/issue #, if applicable: 131432834

## Summary

This adds support for distinct `minimumLength` and `maximumLength` attributes within the top-level, primary "Attributes" section that may be rendered for REST documentation pages.

## Testing

Steps:
1. Verify that the "Minimum Length" and "Maximum Length" fields show up in the "Attributes" section for a page with relevant data

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
