### PR TITLE
Anchor links shouldn't overwrite query parameters

### DIFF
--- a/src/components/ContentNode/LinkableHeading.vue
+++ b/src/components/ContentNode/LinkableHeading.vue
@@ -15,7 +15,7 @@
   >
     <router-link
       v-if="shouldLink"
-      :to="{ hash: `#${anchor}` }"
+      :to="linkWithAnchor"
       :data-after-text="$t('accessibility.in-page-link')"
       class="header-anchor"
       @click="handleFocusAndScroll(anchor)"
@@ -64,6 +64,7 @@ export default {
       enableMinimized,
       isTargetIDE,
     }) => !!anchor && !enableMinimized && !isTargetIDE,
+    linkWithAnchor: ({ anchor, $route }) => ({ hash: `#${anchor}`, query: $route.query }),
   },
 };
 </script>

--- a/tests/unit/components/ContentNode/LinkableHeading.spec.js
+++ b/tests/unit/components/ContentNode/LinkableHeading.spec.js
@@ -17,9 +17,18 @@ describe('LinkableHeading', () => {
   });
   const stubs = { 'router-link': RouterLinkStub };
 
+  const mocks = {
+    $route: {
+      query: {
+        context: 'foo',
+      },
+    },
+  };
+
   it('renders a default heading that is a h2 by default', () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
+      mocks,
       slots: { default: 'Title' },
     });
     expect(wrapper.text()).toBe('Title');
@@ -29,6 +38,7 @@ describe('LinkableHeading', () => {
   it('renders a heading with a given level', () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
+      mocks,
       propsData: {
         level: 3,
       },
@@ -39,6 +49,7 @@ describe('LinkableHeading', () => {
   it('renders a heading with a header anchor and an id on the wrapper', async () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
+      mocks,
       propsData: {
         anchor: 'title',
       },
@@ -47,7 +58,7 @@ describe('LinkableHeading', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.attributes('id')).toBe('title');
     const headerAnchor = wrapper.find('.header-anchor');
-    expect(headerAnchor.props('to')).toEqual({ hash: '#title' });
+    expect(headerAnchor.props('to')).toEqual({ hash: '#title', query: mocks.$route.query });
     expect(headerAnchor.text()).toBe('Title');
     expect(headerAnchor.attributes('data-after-text')).toBe('accessibility.in-page-link');
   });
@@ -60,6 +71,7 @@ describe('LinkableHeading', () => {
   it('does not render anchor if target ide is true', () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
+      mocks,
       propsData: {
         anchor: 'title',
       },
@@ -73,6 +85,7 @@ describe('LinkableHeading', () => {
   it('does not render anchor if `enableMinimized` is true', () => {
     const wrapper = shallowMount(LinkableHeading, {
       stubs,
+      mocks,
       propsData: {
         anchor: 'title',
       },

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyTable.spec.js
@@ -34,6 +34,14 @@ const store = {
   },
 };
 
+const mocks = {
+  $route: {
+    query: {
+      context: 'foo',
+    },
+  },
+};
+
 describe('PropertyTable', () => {
   const propsData = {
     kind: 'restResponses',
@@ -116,6 +124,7 @@ describe('PropertyTable', () => {
     return mount(PropertyTable, {
       stubs: ['ContentNode', 'router-link'],
       propsData,
+      mocks,
       provide,
       ...options,
     });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestParameters.spec.js
@@ -45,6 +45,14 @@ describe('RestParameters', () => {
     },
   };
 
+  const mocks = {
+    $route: {
+      query: {
+        context: 'foo',
+      },
+    },
+  };
+
   function mountComponent({ propsData: props, ...others } = {}) {
     return mount(RestParameters, {
       stubs: ['ContentNode', 'router-link'],
@@ -52,6 +60,7 @@ describe('RestParameters', () => {
         ...propsData,
         ...props,
       },
+      mocks,
       provide,
       ...others,
     });

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/RestResponses.spec.js
@@ -54,11 +54,20 @@ describe('RestResponses', () => {
     },
   };
 
+  const mocks = {
+    $route: {
+      query: {
+        context: 'foo',
+      },
+    },
+  };
+
   function mountComponent(options) {
     const wrapper = mount(RestResponses, {
       stubs: ['ContentNode', 'router-link'],
       propsData,
       provide,
+      mocks,
       ...options,
     });
     return wrapper;


### PR DESCRIPTION
Bug/issue #137046794, if applicable: 

## Summary

Anchor links shouldn't overwrite query parameters. For the Routerlink component to preserve the query, we need to pass the
routers query as a query parameter to the "to" prop.

## Dependencies

NA

## Testing

Steps:
1. Run this project using any .doccarchive
2. Add any query in the URL, example: `?context=foo`
3. Click in a title anchor
4. Assert that the query in the URL doesn't get overwritten

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
