### PR TITLE
Fix regression with edge case where navigator may display wrong data

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -184,8 +184,17 @@ export function getSiblings(uid, childrenMap, children) {
  */
 export function flattenNavigationIndex(indexData) {
   return Object.entries(indexData).reduce((acc, [language, data]) => {
+    // most of the time, it is expected that `data` always has a single item
+    // that represents the top-level root node of the navigation tree
+    //
+    // there may be rare, unexpected scenarios where multiple top-level root
+    // nodes are provide for some reason—if that happens, we would prefer any
+    // categorized as a module
+    const topLevelNode = data.length === 1 ? data[0] : (data.find(node => (
+      node.type === TopicTypes.module
+    )) ?? data[0]);
     acc[language] = flattenNestedData(
-      data[0].children || [], null, 0, data[0].beta,
+      topLevelNode.children || [], null, 0, topLevelNode.beta,
     );
     return acc;
   }, {});

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -10,6 +10,7 @@
 
 import {
   convertChildrenArrayToObject,
+  extractTechnologyProps,
   flattenNavigationIndex,
   flattenNestedData,
   getAllChildren,
@@ -319,62 +320,83 @@ describe('index data', () => {
   });
 });
 
-describe('flattenNavigationIndex', () => {
-  it('prefers modules as navigator data when multiple top-level children are provided', () => {
-    const a = {
-      type: 'overview',
-      title: 'a',
-      path: '/tutorials/a',
-      children: [
-        {
-          type: 'project',
-          title: 'a1',
-          path: '/tutorials/a/a1',
-        },
-      ],
-    };
-    const b = {
-      type: 'module',
-      title: 'a',
-      path: '/documentation/b',
-      children: [
-        {
-          type: 'article',
-          title: 'b1',
-          path: '/documentation/b/b1',
-        },
-      ],
-    };
-    const c = {
-      type: 'other',
-      title: 'c',
-      path: '/documentation/c',
-      children: [
-        {
-          type: 'article',
-          title: 'c1',
-          path: '/documentation/c/c1',
-        },
-      ],
-    };
+describe('when multiple top-level children are provided', () => {
+  const a = {
+    type: 'overview',
+    title: 'a',
+    path: '/tutorials/a',
+    children: [
+      {
+        type: 'project',
+        title: 'a1',
+        path: '/tutorials/a/a1',
+      },
+    ],
+  };
+  const b = {
+    type: 'module',
+    title: 'a',
+    path: '/documentation/b',
+    children: [
+      {
+        type: 'article',
+        title: 'b1',
+        path: '/documentation/b/b1',
+      },
+    ],
+  };
+  const c = {
+    type: 'other',
+    title: 'c',
+    path: '/documentation/c',
+    children: [
+      {
+        type: 'article',
+        title: 'c1',
+        path: '/documentation/c/c1',
+      },
+    ],
+  };
 
-    // use first root node if only one is provided
-    let flattenedIndex = flattenNavigationIndex({ swift: [a] });
-    expect(flattenedIndex.swift.length).toBe(1);
-    expect(flattenedIndex.swift[0].title).toBe(a.children[0].title);
-    flattenedIndex = flattenNavigationIndex({ swift: [b] });
-    expect(flattenedIndex.swift.length).toBe(1);
-    expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
+  describe('flattenNavigationIndex', () => {
+    it('prefers modules', () => {
+      // use first root node if only one is provided
+      let flattenedIndex = flattenNavigationIndex({ swift: [a] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(a.children[0].title);
+      flattenedIndex = flattenNavigationIndex({ swift: [b] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
 
-    // prefer "module" root when multiple top-level nodes are provided
-    flattenedIndex = flattenNavigationIndex({ swift: [a, b] });
-    expect(flattenedIndex.swift.length).toBe(1);
-    expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
+      // prefer "module" root when multiple top-level nodes are provided
+      flattenedIndex = flattenNavigationIndex({ swift: [a, b] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
 
-    // fallback to first root node when multiple top-level nodes are provided
-    // and none of them is a "module"
-    flattenedIndex = flattenNavigationIndex({ swift: [c, a] });
-    expect(flattenedIndex.swift.length).toBe(1);
-    expect(flattenedIndex.swift[0].title).toBe(c.children[0].title);
+      // fallback to first root node when multiple top-level nodes are provided
+      // and none of them is a "module"
+      flattenedIndex = flattenNavigationIndex({ swift: [c, a] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(c.children[0].title);
+    });
+  });
+
+  describe('extractTechnologyProps', () => {
+    it('prefers modules', () => {
+      // use first root node if only one is provided
+      let props = extractTechnologyProps({ swift: [a] });
+      expect(props.swift.technology).toBe(a.title);
+      props = extractTechnologyProps({ swift: [b] });
+      expect(props.swift.technology).toBe(b.title);
+
+      // prefer "module" root when multiple top-level nodes are provided
+      props = extractTechnologyProps({ swift: [a, b] });
+      expect(props.swift.technology).toBe(b.title);
+
+      // fallback to first root node when multiple top-level nodes are provided
+      // and none of them is a "module"
+      props = extractTechnologyProps({ swift: [c, a] });
+      expect(props.swift.technology).toBe(c.title);
+    });
   });
 });

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -10,6 +10,7 @@
 
 import {
   convertChildrenArrayToObject,
+  flattenNavigationIndex,
   flattenNestedData,
   getAllChildren,
   getChildren,
@@ -315,5 +316,65 @@ describe('index data', () => {
   it('it gets all sibling nodes of a node', () => {
     const childNodes = getSiblings(root0Child1.uid, childrenMap, children);
     expect(childNodes).toEqual([root0Child0, root0Child1]);
+  });
+});
+
+describe('flattenNavigationIndex', () => {
+  it('prefers modules as navigator data when multiple top-level children are provided', () => {
+    const a = {
+      type: 'overview',
+      title: 'a',
+      path: '/tutorials/a',
+      children: [
+        {
+          type: 'project',
+          title: 'a1',
+          path: '/tutorials/a/a1',
+        },
+      ],
+    };
+    const b = {
+      type: 'module',
+      title: 'a',
+      path: '/documentation/b',
+      children: [
+        {
+          type: 'article',
+          title: 'b1',
+          path: '/documentation/b/b1',
+        },
+      ],
+    };
+    const c = {
+      type: 'other',
+      title: 'c',
+      path: '/documentation/c',
+      children: [
+        {
+          type: 'article',
+          title: 'c1',
+          path: '/documentation/c/c1',
+        },
+      ],
+    };
+
+    // use first root node if only one is provided
+    let flattenedIndex = flattenNavigationIndex({ swift: [a] });
+    expect(flattenedIndex.swift.length).toBe(1);
+    expect(flattenedIndex.swift[0].title).toBe(a.children[0].title);
+    flattenedIndex = flattenNavigationIndex({ swift: [b] });
+    expect(flattenedIndex.swift.length).toBe(1);
+    expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
+
+    // prefer "module" root when multiple top-level nodes are provided
+    flattenedIndex = flattenNavigationIndex({ swift: [a, b] });
+    expect(flattenedIndex.swift.length).toBe(1);
+    expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
+
+    // fallback to first root node when multiple top-level nodes are provided
+    // and none of them is a "module"
+    flattenedIndex = flattenNavigationIndex({ swift: [c, a] });
+    expect(flattenedIndex.swift.length).toBe(1);
+    expect(flattenedIndex.swift[0].title).toBe(c.children[0].title);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 140370212

## Summary

This re-introduces logic removed by #904 that was needed to handle an edge case where the navigator needs to decide between data for 2 distinct navigation trees in the rare scenario where it is provided in the IndexJSON by DocC.

There will usually only be data for a single tree provided, but in the rare scenario where multiple are provided, we should prefer the tree with the `"module"` root.

## Testing

Steps:
1. Verify that there are no regressions in behavior with loading/displaying data from Index JSON in the sidebar navigator.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
