### PR TITLE
Use theme import for `filterInactiveReferences`

### DIFF
--- a/src/stores/DocumentationTopicStore.js
+++ b/src/stores/DocumentationTopicStore.js
@@ -8,7 +8,7 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { filterInactiveReferences } from 'docc-render/utils/references';
+import { filterInactiveReferences } from 'theme/utils/references';
 import ApiChangesStoreBase from 'docc-render/stores/ApiChangesStoreBase';
 import OnThisPageSectionsStoreBase from 'docc-render/stores/OnThisPageSectionsStoreBase';
 import Settings from 'docc-render/utils/settings';


### PR DESCRIPTION
Bug/issue #, if applicable: 141015022

## Summary

The theme import variant allows this behavior to be adjusted if desired.

## Testing

Steps:
1. Verify that there are no changes in behavior to the existing logic for filtering external references.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (minor syntax change that isn't directly testable)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
