### PR TITLE
Unify time transitions across the Navigator

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -464,7 +464,7 @@ export default {
     left: 0;
     z-index: $nav-z-index + 1;
     transform: translateX(-100%);
-    transition: transform 0.15s ease-in;
+    transition: transform var(--nav-transition-duration) ease-in;
     left: 0;
 
     :deep(.aside-animated-child) {
@@ -477,8 +477,9 @@ export default {
       :deep(.aside-animated-child) {
         --index: 0;
         opacity: 1;
-        transition: opacity 0.15s linear;
-        transition-delay: calc(var(--index) * 0.15s + 0.15s);
+        transition: opacity var(--nav-transition-duration) linear;
+        transition-delay:
+          calc(var(--index) * var(--nav-transition-duration) + var(--nav-transition-duration));
       }
     }
 

--- a/src/components/DocumentationLayout.vue
+++ b/src/components/DocumentationLayout.vue
@@ -245,14 +245,14 @@ export default {
 }
 
 .documentation-layout {
-  --delay: 1s;
+  --nav-transition-duration: 0.15s;
   display: flex;
   flex-flow: column;
   background: var(--colors-text-background, var(--color-text-background));
 
   .delay-hiding-leave-active {
     // don't hide navigator until delay time has passed
-    transition: display var(--delay);
+    transition: display var(--nav-transition-duration);
   }
 }
 


### PR DESCRIPTION
Bug/issue #141189589, if applicable: 

## Summary

In 2022 we introduced a delay to hide the content of the navigator in [this commit](https://github.com/swiftlang/swift-docc-render/pull/296/commits/adce95906737362cfa16c2522bd0e6778bb2b0f2).

It was intended [to delay closing the navigator](https://github.com/swiftlang/swift-docc-render/pull/296#discussion_r871228205), so the horizontal transitions we have for the aside element would still work and we would also prevent keyboard navigation for AX reasons.

There are 2 transitions happening:
1) The `aside` element moves to the left
2) The navigator content gets hidden. We need this navigator content to hide for AX reasons explained [here](https://github.com/swiftlang/swift-docc-render/pull/296#discussion_r873715761).

Disclaimer: In the following videos I increased both transitions to 3.5 seconds so it's easier to see. In reality they are much faster.

The following video shows how it currently works in `main`, keeping the delay of the navigator content transition. This delay keeps the content of the navigator while it closes, for aesthetic reasons.

https://github.com/user-attachments/assets/860aa017-2b2d-4b5e-8d37-298bf5f23685

The following video shows how it works if we delete the delay of the navigator content transition. As you can notice, it's much tougher, because the content disappears right away the user clicks on it.

https://github.com/user-attachments/assets/0ccd2f54-8695-4901-ba05-f4419393f0d5

We needed to find a solution in the middle.

Since the `aside` element transition is only 0.15s, one possible option was modify the navigator content delay to be 0.15s instead of 1s as it is now.

## Dependencies

NA

## Testing

Steps:
1. Run the project with a .doccarchive
2. Go to any documentation page
3. Assert that the navigator is loading without any delay

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
