### PR TITLE
Handle malformed baseType data with extraneous whitespace

### DIFF
--- a/src/components/DocumentationTopic/PrimaryContent/PropertyListKeyType.vue
+++ b/src/components/DocumentationTopic/PrimaryContent/PropertyListKeyType.vue
@@ -23,7 +23,7 @@ export default {
   },
   computed: {
     englishTypes() {
-      return this.types.map(({
+      return this.sanitizedTypes.map(({
         arrayMode,
         baseType = '*',
       }) => (arrayMode ? (
@@ -32,6 +32,7 @@ export default {
         baseType
       )));
     },
+    sanitizedTypes: ({ sanitizeType, types }) => types.map(sanitizeType),
     typeOutput() {
       if (this.englishTypes.length > 2) {
         return [this.englishTypes.slice(0, this.englishTypes.length - 1).join(', '),
@@ -53,6 +54,14 @@ export default {
       default:
         return type;
       }
+    },
+    // trim extra starting/end whitespace of baseType strings in case they
+    // unexpectedly come through that way in the JSON
+    sanitizeType(type) {
+      const { baseType } = type;
+      return baseType
+        ? { ...type, baseType: baseType.trim() }
+        : type;
     },
   },
 };

--- a/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyListKeyType.spec.js
+++ b/tests/unit/components/DocumentationTopic/PrimaryContent/PropertyListKeyType.spec.js
@@ -60,4 +60,13 @@ describe('PropertyListKeyType', () => {
       { arrayMode: true },
     ]).text()).toBe('* or array of *');
   });
+
+  it('handles extraneous whitespace when pluralizing types', () => {
+    expect(mountWithTypes([
+      {
+        baseType: 'dictionary ',
+        arrayMode: true,
+      },
+    ]).text()).toBe('array of dictionaries');
+  });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 139449414

## Summary

This adds some small sanitization logic to the `PropertyListKeyType` component to better handle situations where it may get `baseType` data that has extraneous leading/trailing whitespace. See the added unit test for an example—in that example, the UI should render "array of dictionaries" instead of "array of dictionary".

## Testing

Steps:
1. See unit test for example.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
