### PR TITLE
Navigator skips empty languages

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -194,11 +194,13 @@ function extractRootNode(data) {
 
 /**
  * Flatten data for each language variant
+ * @param {Object} languages
  * @return { languageVariant: NavigatorFlatItem[] }
  */
-export function flattenNavigationIndex(indexData) {
-  return Object.entries(indexData).reduce((acc, [language, data]) => {
-    const topLevelNode = extractRootNode(data);
+export function flattenNavigationIndex(languages) {
+  return Object.entries(languages).reduce((acc, [language, langData]) => {
+    if (!langData.length) return acc;
+    const topLevelNode = extractRootNode(langData);
     acc[language] = flattenNestedData(
       topLevelNode.children || [], null, 0, topLevelNode.beta,
     );

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -379,6 +379,12 @@ describe('when multiple top-level children are provided', () => {
       expect(flattenedIndex.swift.length).toBe(1);
       expect(flattenedIndex.swift[0].title).toBe(c.children[0].title);
     });
+
+    it('skips empty languages', () => {
+      const flattenedIndex = flattenNavigationIndex({ occ: [], swift: [a] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(a.children[0].title);
+    });
   });
 
   describe('extractTechnologyProps', () => {


### PR DESCRIPTION
Bug/issue #143323864, if applicable: 

## Summary

If an interfaceLanguage is empty, the navigator will skip it.

## Dependencies

NA

## Testing

[index.json.zip](https://github.com/user-attachments/files/18540584/index.json.zip)

Steps:
1. Use the `index.json` file attached to this PR as the index for your navigator
2. Assert that you can visualize the navigator for the swift language 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
