### PR TITLE
[6.1] Navigator skips empty languages

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -180,12 +180,14 @@ export function getSiblings(uid, childrenMap, children) {
 
 /**
  * Flatten data for each language variant
+ * @param {Object} languages
  * @return { languageVariant: NavigatorFlatItem[] }
  */
-export function flattenNavigationIndex(indexData) {
-  return Object.entries(indexData).reduce((acc, [language, data]) => {
+export function flattenNavigationIndex(languages) {
+  return Object.entries(languages).reduce((acc, [language, langData]) => {
+    if (!langData.length) return acc;
     acc[language] = flattenNestedData(
-      data[0].children || [], null, 0, data[0].beta,
+      langData[0].children || [], null, 0, langData[0].beta,
     );
     return acc;
   }, {});
@@ -196,6 +198,7 @@ export function flattenNavigationIndex(indexData) {
  */
 export function extractTechnologyProps(indexData) {
   return Object.entries(indexData).reduce((acc, [language, data]) => {
+    if (!data.length) return acc;
     acc[language] = {
       technology: data[0].title,
       technologyPath: data[0].path || data[0].url,

--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -194,11 +194,13 @@ function extractRootNode(data) {
 
 /**
  * Flatten data for each language variant
+ * @param {Object} languages
  * @return { languageVariant: NavigatorFlatItem[] }
  */
-export function flattenNavigationIndex(indexData) {
-  return Object.entries(indexData).reduce((acc, [language, data]) => {
-    const topLevelNode = extractRootNode(data);
+export function flattenNavigationIndex(languages) {
+  return Object.entries(languages).reduce((acc, [language, langData]) => {
+    if (!langData.length) return acc;
+    const topLevelNode = extractRootNode(langData);
     acc[language] = flattenNestedData(
       topLevelNode.children || [], null, 0, topLevelNode.beta,
     );

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -379,6 +379,12 @@ describe('when multiple top-level children are provided', () => {
       expect(flattenedIndex.swift.length).toBe(1);
       expect(flattenedIndex.swift[0].title).toBe(c.children[0].title);
     });
+
+    it('skips empty languages', () => {
+      const flattenedIndex = flattenNavigationIndex({ occ: [], swift: [a] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(a.children[0].title);
+    });
   });
 
   describe('extractTechnologyProps', () => {

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -16,6 +16,7 @@ import {
   getParents,
   getSiblings,
   hashCode,
+  flattenNavigationIndex,
 } from 'docc-render/utils/navigatorData';
 import { TopicTypes } from '@/constants/TopicTypes';
 import { INDEX_ROOT_KEY } from '@/constants/sidebar';
@@ -315,5 +316,12 @@ describe('index data', () => {
   it('it gets all sibling nodes of a node', () => {
     const childNodes = getSiblings(root0Child1.uid, childrenMap, children);
     expect(childNodes).toEqual([root0Child0, root0Child1]);
+  });
+});
+
+describe('flattenNavigationIndex', () => {
+  it('skips empty languages', () => {
+    const flattenedIndex = flattenNavigationIndex({ occ: [], swift: [technologyWithChildren] });
+    expect(flattenedIndex.swift[0].title).toBe(technologyWithChildren.children[0].title);
   });
 });


### PR DESCRIPTION
- **Explanation:** Navigator skips empty interfaceLanguage
- **Scope:** Navigator
- **Issue:** rdar://143323864
- **Risk:** Low, focused change to the navigator when this one has multiple interface languages
- **Testing:** Unit tests added, manually tested too
- **Reviewer:** @mportiz08 
- **Original PR:** https://github.com/swiftlang/swift-docc-render/pull/922