### PR TITLE
[6.1] Fix regression with edge case where navigator may display wrong data

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -178,14 +178,29 @@ export function getSiblings(uid, childrenMap, children) {
   return getChildren(item.parent, childrenMap, children);
 }
 
+function extractRootNode(data) {
+  // most of the time, it is expected that `data` always has a single item
+  // that represents the top-level root node of the navigation tree
+  //
+  // there may be rare, unexpected scenarios where multiple top-level root
+  // nodes are provide for some reason—if that happens, we would prefer the
+  // first one categorized as a "module"
+  //
+  // otherwise, the first provided node will be used
+  return data.length === 1 ? data[0] : (data.find(node => (
+    node.type === TopicTypes.module
+  )) ?? data[0]);
+}
+
 /**
  * Flatten data for each language variant
  * @return { languageVariant: NavigatorFlatItem[] }
  */
 export function flattenNavigationIndex(indexData) {
   return Object.entries(indexData).reduce((acc, [language, data]) => {
+    const topLevelNode = extractRootNode(data);
     acc[language] = flattenNestedData(
-      data[0].children || [], null, 0, data[0].beta,
+      topLevelNode.children || [], null, 0, topLevelNode.beta,
     );
     return acc;
   }, {});
@@ -196,10 +211,11 @@ export function flattenNavigationIndex(indexData) {
  */
 export function extractTechnologyProps(indexData) {
   return Object.entries(indexData).reduce((acc, [language, data]) => {
+    const topLevelNode = extractRootNode(data);
     acc[language] = {
-      technology: data[0].title,
-      technologyPath: data[0].path || data[0].url,
-      isTechnologyBeta: data[0].beta,
+      technology: topLevelNode.title,
+      technologyPath: topLevelNode.path || topLevelNode.url,
+      isTechnologyBeta: topLevelNode.beta,
     };
     return acc;
   }, {});

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -10,6 +10,8 @@
 
 import {
   convertChildrenArrayToObject,
+  extractTechnologyProps,
+  flattenNavigationIndex,
   flattenNestedData,
   getAllChildren,
   getChildren,
@@ -315,5 +317,86 @@ describe('index data', () => {
   it('it gets all sibling nodes of a node', () => {
     const childNodes = getSiblings(root0Child1.uid, childrenMap, children);
     expect(childNodes).toEqual([root0Child0, root0Child1]);
+  });
+});
+
+describe('when multiple top-level children are provided', () => {
+  const a = {
+    type: 'overview',
+    title: 'a',
+    path: '/tutorials/a',
+    children: [
+      {
+        type: 'project',
+        title: 'a1',
+        path: '/tutorials/a/a1',
+      },
+    ],
+  };
+  const b = {
+    type: 'module',
+    title: 'a',
+    path: '/documentation/b',
+    children: [
+      {
+        type: 'article',
+        title: 'b1',
+        path: '/documentation/b/b1',
+      },
+    ],
+  };
+  const c = {
+    type: 'other',
+    title: 'c',
+    path: '/documentation/c',
+    children: [
+      {
+        type: 'article',
+        title: 'c1',
+        path: '/documentation/c/c1',
+      },
+    ],
+  };
+
+  describe('flattenNavigationIndex', () => {
+    it('prefers modules', () => {
+      // use first root node if only one is provided
+      let flattenedIndex = flattenNavigationIndex({ swift: [a] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(a.children[0].title);
+      flattenedIndex = flattenNavigationIndex({ swift: [b] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
+
+      // prefer "module" root when multiple top-level nodes are provided
+      flattenedIndex = flattenNavigationIndex({ swift: [a, b] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
+
+      // fallback to first root node when multiple top-level nodes are provided
+      // and none of them is a "module"
+      flattenedIndex = flattenNavigationIndex({ swift: [c, a] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(c.children[0].title);
+    });
+  });
+
+  describe('extractTechnologyProps', () => {
+    it('prefers modules', () => {
+      // use first root node if only one is provided
+      let props = extractTechnologyProps({ swift: [a] });
+      expect(props.swift.technology).toBe(a.title);
+      props = extractTechnologyProps({ swift: [b] });
+      expect(props.swift.technology).toBe(b.title);
+
+      // prefer "module" root when multiple top-level nodes are provided
+      props = extractTechnologyProps({ swift: [a, b] });
+      expect(props.swift.technology).toBe(b.title);
+
+      // fallback to first root node when multiple top-level nodes are provided
+      // and none of them is a "module"
+      props = extractTechnologyProps({ swift: [c, a] });
+      expect(props.swift.technology).toBe(c.title);
+    });
   });
 });


### PR DESCRIPTION
- **Explanation:** Fixes regression where navigator may display wrong tree when provided multiple options from Index JSON
- **Scope:** Impacts the sidebar navigator in rare cases
- **Issue:** rdar://140370212
- **Risk:** Low, small additional code change to make preferred choice when provided multiple trees of data
- **Testing:** Unit tests added, manually tested with problematic content and existing content without problematic content
- **Reviewer:** Hanqing Huang
- **Original PR:** https://github.com/swiftlang/swift-docc-render/pull/916