### PR TITLE
[6.1] Use theme import for `filterInactiveReferences`

### DIFF
--- a/src/stores/DocumentationTopicStore.js
+++ b/src/stores/DocumentationTopicStore.js
@@ -8,7 +8,7 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { filterInactiveReferences } from 'docc-render/utils/references';
+import { filterInactiveReferences } from 'theme/utils/references';
 import ApiChangesStoreBase from 'docc-render/stores/ApiChangesStoreBase';
 import OnThisPageSectionsStoreBase from 'docc-render/stores/OnThisPageSectionsStoreBase';
 import Settings from 'docc-render/utils/settings';


### PR DESCRIPTION
- **Explanation:** Allows behavior of `filterInactiveReferences` function to be adjusted if configured
- **Scope:** Impacts app-wide logic that may result in links being disabled in certain contexts
- **Issue:** rdar://141015022
- **Risk:** Low, single import source change that has no direct impact on the existing codebase
- **Testing:** Existing unit tests continue to pass, no disruption to existing linking behavior
- **Reviewer:** @eango 
- **Original PR:** https://github.com/swiftlang/swift-docc-render/pull/917