### PR TITLE
[6.1] Unify time transitions across the Navigator

### DIFF
--- a/src/components/AdjustableSidebarWidth.vue
+++ b/src/components/AdjustableSidebarWidth.vue
@@ -464,7 +464,7 @@ export default {
     left: 0;
     z-index: $nav-z-index + 1;
     transform: translateX(-100%);
-    transition: transform 0.15s ease-in;
+    transition: transform var(--nav-transition-duration) ease-in;
     left: 0;
 
     :deep(.aside-animated-child) {
@@ -477,8 +477,9 @@ export default {
       :deep(.aside-animated-child) {
         --index: 0;
         opacity: 1;
-        transition: opacity 0.15s linear;
-        transition-delay: calc(var(--index) * 0.15s + 0.15s);
+        transition: opacity var(--nav-transition-duration) linear;
+        transition-delay:
+          calc(var(--index) * var(--nav-transition-duration) + var(--nav-transition-duration));
       }
     }
 

--- a/src/components/DocumentationLayout.vue
+++ b/src/components/DocumentationLayout.vue
@@ -245,14 +245,14 @@ export default {
 }
 
 .documentation-layout {
-  --delay: 1s;
+  --nav-transition-duration: 0.15s;
   display: flex;
   flex-flow: column;
   background: var(--colors-text-background, var(--color-text-background));
 
   .delay-hiding-leave-active {
     // don't hide navigator until delay time has passed
-    transition: display var(--delay);
+    transition: display var(--nav-transition-duration);
   }
 }
 


### PR DESCRIPTION
- **Explanation:** Adjusts timing of animation for sidebar
- **Scope:** Impacts the sidebar when being opened/closed or navigating between pages
- **Issue:** rdar://141189589
- **Risk:** Low, minor CSS changes to animation durations
- **Testing:** Manually/visually tested sidebar animations to ensure they are more performant during transition events
- **Reviewer:** @mportiz08, @eango 
- **Original PR:** https://github.com/swiftlang/swift-docc-render/pull/920