### PR TITLE
Make nav-title 100% width in mobile viewport

### DIFF
--- a/src/components/NavBase.vue
+++ b/src/components/NavBase.vue
@@ -679,11 +679,11 @@ $content-max-width: map-deep-get($breakpoint-attributes, (nav, large, content-wi
   align-items: center;
   white-space: nowrap;
   box-sizing: border-box;
+  overflow: hidden;
 
   @include breakpoint(small, $scope: nav) {
     padding-top: 0;
     height: $nav-height-small;
-    width: 90%;
   }
 
   :deep(span) {

--- a/src/components/Tutorial/NavigationBar.vue
+++ b/src/components/Tutorial/NavigationBar.vue
@@ -259,7 +259,6 @@ export default {
 
 .nav :deep(.nav-title) {
   grid-column: 1;
-  width: 90%;
   padding-top: 0;
 }
 


### PR DESCRIPTION
Bug/issue #137436968, if applicable: 

## Summary

This is a small change to make the nav-title to be 100% width in mobile viewport instead of 90%.
There was no reason for it to be 90% instead.

## Dependencies

NA

## Testing

Steps:
1. Go to any documentation or tutorial page
2. Assert that the nav title looks correct in mobile viewport

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
