### PR TITLE
Rely on URL paths when choosing among multiple indices

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -182,7 +182,7 @@ function extractRootNode(data) {
   // note: this "root" path won't always necessarily come at the beginning of
   // the URL in situations where the renderer is being hosted at some path
   // prefix
-  const rootPathPattern = /^.*(\/documentation\/[^/]+).*$/;
+  const rootPathPattern = /(\/documentation\/[^/]+)/;
   const rootPath = window.location.href.match(rootPathPattern)?.[1] ?? '';
   // most of the time, it is expected that `data` always has a single item
   // that represents the top-level root node of the navigation tree

--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -179,16 +179,21 @@ export function getSiblings(uid, childrenMap, children) {
 }
 
 function extractRootNode(data) {
+  // note: this "root" path won't always necessarily come at the beginning of
+  // the URL in situations where the renderer is being hosted at some path
+  // prefix
+  const rootPathPattern = /^.*(\/documentation\/[^/]+).*$/;
+  const rootPath = window.location.href.match(rootPathPattern)?.[1] ?? '';
   // most of the time, it is expected that `data` always has a single item
   // that represents the top-level root node of the navigation tree
   //
   // there may be rare, unexpected scenarios where multiple top-level root
-  // nodes are provide for some reason—if that happens, we would prefer the
-  // first one categorized as a "module"
+  // nodes are provide for some reason—if that happens, we would prefer the one
+  // with a path that most closely resembles the current URL path
   //
   // otherwise, the first provided node will be used
   return data.length === 1 ? data[0] : (data.find(node => (
-    node.type === TopicTypes.module
+    node.path.toLowerCase() === rootPath.toLowerCase()
   )) ?? data[0]);
 }
 

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -359,7 +359,11 @@ describe('when multiple top-level children are provided', () => {
   };
 
   describe('flattenNavigationIndex', () => {
-    it('prefers modules', () => {
+    it('prefers the root child with the same url path prefix', () => {
+      Object.defineProperty(window, 'location', {
+        value: { href: 'http://localhost/documentation/b/b42' },
+      });
+
       // use first root node if only one is provided
       let flattenedIndex = flattenNavigationIndex({ swift: [a] });
       expect(flattenedIndex.swift.length).toBe(1);
@@ -368,7 +372,7 @@ describe('when multiple top-level children are provided', () => {
       expect(flattenedIndex.swift.length).toBe(1);
       expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
 
-      // prefer "module" root when multiple top-level nodes are provided
+      // prefers root node with same url path prefix when multiple are provided
       flattenedIndex = flattenNavigationIndex({ swift: [a, b] });
       expect(flattenedIndex.swift.length).toBe(1);
       expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
@@ -388,14 +392,18 @@ describe('when multiple top-level children are provided', () => {
   });
 
   describe('extractTechnologyProps', () => {
-    it('prefers modules', () => {
+    it('prefers the root child with the same url path prefix', () => {
+      Object.defineProperty(window, 'location', {
+        value: { href: 'http://localhost/documentation/b/b42' },
+      });
+
       // use first root node if only one is provided
       let props = extractTechnologyProps({ swift: [a] });
       expect(props.swift.technology).toBe(a.title);
       props = extractTechnologyProps({ swift: [b] });
       expect(props.swift.technology).toBe(b.title);
 
-      // prefer "module" root when multiple top-level nodes are provided
+      // prefers root node with same url path prefix when multiple are provided
       props = extractTechnologyProps({ swift: [a, b] });
       expect(props.swift.technology).toBe(b.title);
 


### PR DESCRIPTION
Bug/issue #, if applicable: 142337934

## Summary

This updates the logic used to choose between multiple top-level trees of data for the sidebar navigator:

Before, it would pick the first `module` in the list. (see #916)

Now, it will pick the first node with a path prefix matches the path prefix of the current URL.

This logic should only apply to rare scenarios where multiple trees of index data are included in a single Index JSON file.

## Testing

Steps:
1. Verify that there are no regressions with loading sidebar data in common, single-root scenarios.
2. Verify that the data loaded for the index generally matches what would be expected given the current URL in scenarios where there are multiple roots of index data.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
