### PR TITLE
Normalize path of icon URL

### DIFF
--- a/src/components/SVGIcon.vue
+++ b/src/components/SVGIcon.vue
@@ -15,13 +15,19 @@
     xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink"
   >
-    <use v-if="themeOverrideURL" :href="`${themeOverrideURL}#${themeId}`" width="100%" height="100%" />
+    <use
+      v-if="themeOverrideURL"
+      :href="normalizePath(`${themeOverrideURL}#${themeId}`)"
+      width="100%"
+      height="100%"
+    />
     <slot v-else />
   </svg>
 </template>
 
 <script>
 import { getSetting } from 'docc-render/utils/theme-settings';
+import { normalizePath } from 'docc-render/utils/assets';
 
 export default {
   name: 'SVGIcon',
@@ -34,6 +40,9 @@ export default {
       type: String,
       default: null,
     },
+  },
+  methods: {
+    normalizePath,
   },
   computed: {
     themeOverrideURL: ({ iconUrl, themeId }) => iconUrl || getSetting([

--- a/tests/unit/components/SVGIcon.spec.js
+++ b/tests/unit/components/SVGIcon.spec.js
@@ -16,6 +16,12 @@ jest.mock('docc-render/utils/theme-settings');
 
 getSetting.mockReturnValue(undefined);
 
+const mockBaseUrl = '/developer/';
+
+jest.mock('docc-render/utils/assets', () => ({
+  normalizePath: jest.fn(name => mockBaseUrl + name),
+}));
+
 const createWrapper = attrs => shallowMount(SVGIcon, {
   slots: {
     default: '<path d="M8.33"></path>',
@@ -46,7 +52,7 @@ describe('SVGIcon', () => {
     expect(wrapper.find('use').attributes()).toEqual({
       width: '100%',
       height: '100%',
-      href: 'theme/override/path#foo',
+      href: `${mockBaseUrl}theme/override/path#foo`,
     });
   });
 
@@ -62,7 +68,7 @@ describe('SVGIcon', () => {
     expect(wrapper.find('use').attributes()).toEqual({
       width: '100%',
       height: '100%',
-      href: '/path/to/new/icon.svg#foo',
+      href: `${mockBaseUrl}/path/to/new/icon.svg#foo`,
     });
   });
 });


### PR DESCRIPTION
Bug/issue #146669359, if applicable: 

## Summary

In case we render a SVG passing a iconURL or by the theme-settings json file, we need to normalize the path to add any possible baseUrl to it.

## Dependencies

NA

## Testing

Steps:
1. Use a doccarchive that contains SVG icons paths to render
2. Run the server passing a baseUrl to it `BASE_URL='/foo/' npm run serve`
3. Assert that the icons paths are being prefixed, along with the rest of the app

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
