### PR TITLE
[Regression] [Performance] Fix delayed sidebar hover animation for large projects

### DIFF
--- a/src/mixins/indexDataFetcher.js
+++ b/src/mixins/indexDataFetcher.js
@@ -28,7 +28,8 @@ export default {
           interfaceLanguages,
           references = {},
         } = await fetchData(this.indexDataPath);
-        IndexStore.setFlatChildren(flattenNavigationIndex(interfaceLanguages));
+        const flatChildren = Object.freeze(flattenNavigationIndex(interfaceLanguages));
+        IndexStore.setFlatChildren(flatChildren);
         IndexStore.setTechnologyProps(extractTechnologyProps(interfaceLanguages));
         IndexStore.setReferences(references);
         IndexStore.setIncludedArchiveIdentifiers(includedArchiveIdentifiers);


### PR DESCRIPTION
Bug/issue #, if applicable: #919 (rdar://147239963)

## Summary

Fixes a regression with the performance of the sidebar hover animation that can be very slow for large projects with many sidebar items.

This regression was introduced with #904.

The cause of the poor performance turned out to be a big jump in memory usage, which noticeably impacted the performance of hovering over sidebar items. By utilizing `Object.freeze` again, we prevent Vue from creating a large number of proxy items that it would normally use to track changes to state data and thereby keep the memory usage down for projects with many index nodes. Since we don't modify this data after fetching/deserializing it, this should be an acceptable tradeoff.

In the future if we need to handle even larger amounts of data or need to track changes to these nodes, we will likely need to come up with a way of streaming this data instead of storing it all in memory.

## Testing

Steps:
1. Use this branch to render a DocC catalog with a large number of navigation items.
2. Compare the performance of the hover effect for sidebar items and/or compare JS heap snapshots between this branch and the main branch to verify that the memory usage and performance better matches the behavior before #904 was merged.
3. Ensure there are no behavioral regressions with the function of the sidebar.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (no straightforward way to unit test this change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
