### PR TITLE
Compare page and node URLs less strictly when choosing between multiple indices

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -193,7 +193,7 @@ function extractRootNode(data) {
   //
   // otherwise, the first provided node will be used
   return data.length === 1 ? data[0] : (data.find(node => (
-    node.path.toLowerCase() === rootPath.toLowerCase()
+    node.path.toLowerCase().endsWith(rootPath.toLowerCase())
   )) ?? data[0]);
 }
 

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -357,6 +357,18 @@ describe('when multiple top-level children are provided', () => {
       },
     ],
   };
+  const b2 = {
+    type: 'module',
+    title: 'b',
+    path: '/some/prefix/documentation/b',
+    children: [
+      {
+        type: 'article',
+        title: 'b1',
+        path: '/some/prefix/documentation/b/b1',
+      },
+    ],
+  };
 
   describe('flattenNavigationIndex', () => {
     it('prefers the root child with the same url path prefix', () => {
@@ -376,6 +388,9 @@ describe('when multiple top-level children are provided', () => {
       flattenedIndex = flattenNavigationIndex({ swift: [a, b] });
       expect(flattenedIndex.swift.length).toBe(1);
       expect(flattenedIndex.swift[0].title).toBe(b.children[0].title);
+      flattenedIndex = flattenNavigationIndex({ swift: [a, b2] });
+      expect(flattenedIndex.swift.length).toBe(1);
+      expect(flattenedIndex.swift[0].title).toBe(b2.children[0].title);
 
       // fallback to first root node when multiple top-level nodes are provided
       // and none of them is a "module"
@@ -406,6 +421,8 @@ describe('when multiple top-level children are provided', () => {
       // prefers root node with same url path prefix when multiple are provided
       props = extractTechnologyProps({ swift: [a, b] });
       expect(props.swift.technology).toBe(b.title);
+      props = extractTechnologyProps({ swift: [a, b2] });
+      expect(props.swift.technology).toBe(b2.title);
 
       // fallback to first root node when multiple top-level nodes are provided
       // and none of them is a "module"


### PR DESCRIPTION
Bug/issue #, if applicable: 147829785

## Summary

Fixes an edge case for #929 where the added logic doesn't apply cleanly when the node path in some Index JSON data includes some prefix before the `/documentation` segment.

By using the `endsWith` comparison instead of `===`, this logic can properly apply to that edge case without impacting the normal scenario with no base URLs.

## Testing

Steps:
1. Ensure #929 testing steps still work as expected
2. Test some content where the Index JSON has multiple top-level trees of data and the node paths include a path prefix before /documentation

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
