### PR TITLE
updates contributing guide to use 'good first issue' instead of StarterBug to be consistent with the rest of swiftlang repositories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,10 +184,10 @@ npm run lint:fix
 ## Your First Contribution
 
 Unsure of where to begin contributing to Swift-DocC-Render? You can start by looking at
-the bugs in the `Swift-DocC-Render` issues list with the `StarterBug` label on
-[GitHub](https://github.com/apple/swift-docc-render/issues?q=is%3Aissue+is%3Aopen+label%3AStarterBug).
+the bugs in the `Swift-DocC-Render` issues list with the `good first issue` label on
+[GitHub](https://github.com/swiftlang/swift-docc-render/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
 
 Once you've found an issue to work on,
 follow the above instructions for [Building Swift-DocC-Render](#build-and-run-swift-docc-render).
 
-<!-- Copyright (c) 2021 Apple Inc and the Swift Project authors. All Rights Reserved. -->
+<!-- Copyright (c) 2025 Apple Inc and the Swift Project authors. All Rights Reserved. -->

--- a/bin/check-source
+++ b/bin/check-source
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][78901234]-20[12][8901234]/YEARS/' -e 's/20[12][8901234]/YEARS/'
+    sed -e 's/20[12][789012345]-20[12][89012345]/YEARS/' -e 's/20[12][89012345]/YEARS/'
 }
 
 printf "=> Checking license headers… "


### PR DESCRIPTION
A small change to tweak the CONTRIBUTING.md guide to reference looking for issues tagged "good first issue" instead of "StarterBug" to be consistent with the rest of the swiftlang organization repositories.