### PR TITLE
extractTechnologyProps skips empty languages

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -217,8 +217,9 @@ export function flattenNavigationIndex(languages) {
  * Extract technology data for each language variant
  */
 export function extractTechnologyProps(indexData) {
-  return Object.entries(indexData).reduce((acc, [language, data]) => {
-    const topLevelNode = extractRootNode(data);
+  return Object.entries(indexData).reduce((acc, [language, langData]) => {
+    if (!langData.length) return acc;
+    const topLevelNode = extractRootNode(langData);
     acc[language] = {
       technology: topLevelNode.title,
       technologyPath: topLevelNode.path || topLevelNode.url,

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -429,5 +429,10 @@ describe('when multiple top-level children are provided', () => {
       props = extractTechnologyProps({ swift: [c, a] });
       expect(props.swift.technology).toBe(c.title);
     });
+
+    it('skips empty languages', () => {
+      const props = extractTechnologyProps({ occ: [], swift: [a] });
+      expect(props.swift.technology).toBe(a.title);
+    });
   });
 });


### PR DESCRIPTION
Bug/issue #149310949, if applicable: 

## Summary

When we try to extract technologies props, it fails if the interfaceLanguage has an empty technology. This change allows it to skip empty languages.

## Dependencies

This is related to a previous fix https://github.com/swiftlang/swift-docc-render/pull/922

## Testing

[index.json.zip](https://github.com/user-attachments/files/18540584/index.json.zip)

Steps:
1. Use the `index.json` file attached to this PR as the index for your navigator
2. Assert that you can visualize the navigator for the swift language 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [x] Updated documentation if necessary
