### PR TITLE
[TutorialsOverview] Ensure body always has dark background

### DIFF
--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -117,6 +117,15 @@ export default {
 };
 </script>
 
+<style lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+// ensure body background is also always dark
+body:has(.tutorials-overview) {
+  --color-text-background: #{dark-color(fill)};
+}
+</style>
+
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 


### PR DESCRIPTION
Bug/issue #, if applicable: 151701111

## Summary

Adds a small CSS rule to ensure that the `body` always has a dark background for the "tutorials overview" page, since it always has a dark theme, regardless of the user/system preferences.

## Testing

Steps:
1. Open a tutorials-overview page.
2. Verify that the `body` background is always black, no matter what the macOS system appearance setting and/or color scheme toggle is set to (may need to inspect it since it is usually covered up by other elements with a dark background)

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] ~~Added tests~~ (CSS-only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
