### PR TITLE
[6.2-20250502] Ensure body bg is always dark for tutorials-overview page

### DIFF
--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -117,6 +117,15 @@ export default {
 };
 </script>
 
+<style lang="scss">
+@import 'docc-render/styles/_core.scss';
+
+// ensure body background is also always dark
+body:has(.tutorials-overview) {
+  --color-text-background: #{dark-color(fill)};
+}
+</style>
+
 <style scoped lang="scss">
 @import 'docc-render/styles/_core.scss';
 


### PR DESCRIPTION
- **Explanation:** Fixes issue where body bg color may be light in certain situations
- **Scope:** Only impacts tutorial-overview pages, small CSS addition
- **Issue:** rdar://151701111
- **Risk:** Low, minor CSS addition to specific page type
- **Testing:** Manually tested that body bg is always dark, regardless of system/user appearance settings
- **Reviewer:** @marinaaisa 
- **Original PR:** #943 