### PR TITLE
Fix crash when subheading is clicked on ObjC page

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -303,7 +303,7 @@ export default {
   },
   beforeRouteUpdate(to, from, next) {
     if (to.path === from.path && to.query.language === Language.objectiveC.key.url
-      && this.objcOverrides) {
+      && from?.query?.language !== Language.objectiveC.key.url && this.objcOverrides) {
       this.applyObjcOverrides();
       next();
     } else if (shouldFetchDataForRouteUpdate(to, from)) {


### PR DESCRIPTION
Bug/issue #, if applicable: 154225522

## Summary

When viewing the Objective-C variant of a documentation page, the renderer may crash when navigating to a different part of the page using a hash fragment, like when clicking a subheading for example.

This happens because there is a patch of data used to transform the original Swift Render JSON into the Objective-C variant—this patch is mistakenly getting applied twice when navigating from the Objective-C version to a different location on the same page using on-page links.

## Testing

Steps:
1. Find an example symbol documentation page which has both Swift and Objective-C variants and switch to the Objective-C variant.
2. Find a link to something on the same page like a subheading and click it.
3. Verify that the renderer no longer crashes.
4. Verify that there are no regressions introduced when navigating to other pages, the same page, or using the language toggle.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
