### PR TITLE
[6.2] Fix crash when subheading is clicked on ObjC page

### DIFF
--- a/src/views/DocumentationTopic.vue
+++ b/src/views/DocumentationTopic.vue
@@ -303,7 +303,7 @@ export default {
   },
   beforeRouteUpdate(to, from, next) {
     if (to.path === from.path && to.query.language === Language.objectiveC.key.url
-      && this.objcOverrides) {
+      && from?.query?.language !== Language.objectiveC.key.url && this.objcOverrides) {
       this.applyObjcOverrides();
       next();
     } else if (shouldFetchDataForRouteUpdate(to, from)) {


### PR DESCRIPTION
- **Explanation:** Fixes issue where clicking a link to a target on the same page of an Objective-C API may crash the renderer.
- **Scope:** Impacts DocC generated API symbol pages with ObjC variants that have links to fragment identifiers.
- **Issue:** rdar://154225522
- **Risk:** Low, single addition to conditional for specific kinds of pages
- **Testing:** Added unit tests, manually tested that jumping between sections of an ObjC symbol page doesn't crash anymore and there are no regressions switching between Swift/ObjC pages.
- **Reviewer:** @marinaaisa 
- **Original PR:** #951 