### PR TITLE
Implement highlight/strikeout/wrap for code listings

### DIFF
--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -277,6 +277,7 @@ function renderNode(createElement, references) {
         copyToClipboard: node.copyToClipboard ?? false,
         wrap: node.wrap ?? 0,
         highlightedLines: node.highlight ?? [],
+        strikethroughLines: node.strikeout ?? [],
       };
       return createElement(CodeListing, { props });
     }

--- a/src/components/ContentNode.vue
+++ b/src/components/ContentNode.vue
@@ -275,6 +275,8 @@ function renderNode(createElement, references) {
         content: node.code,
         showLineNumbers: node.showLineNumbers,
         copyToClipboard: node.copyToClipboard ?? false,
+        wrap: node.wrap ?? 0,
+        highlightedLines: node.highlight ?? [],
       };
       return createElement(CodeListing, { props });
     }

--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -42,7 +42,8 @@
       ><span
         :key="index"
         :class="['code-line-container',{ highlighted: isHighlighted(index),
-                 'user-highlighted': isUserHighlighted(index) }]"
+                 'user-highlighted': isUserHighlighted(index),
+                 'user-strikethrough': isUserStrikethrough(index),}]"
       ><span
         v-if="showLineNumbers"
         class="code-number"
@@ -113,6 +114,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    strikethroughLines: {
+      type: Array,
+      default: () => [],
+    },
     startLineNumber: {
       type: Number,
       default: () => 1,
@@ -143,6 +148,10 @@ export default {
       const arr = this.highlightedLines || [];
       return new Set(arr.map(Number).filter(n => Number.isFinite(n) && n > 0));
     },
+    strikethroughSet() {
+      const arr = this.strikethroughLines || [];
+      return new Set(arr.map(Number).filter(n => Number.isFinite(n) && n > 0));
+    },
     wrapStyle() {
       const style = {};
       if (this.wrap > 0) {
@@ -168,6 +177,9 @@ export default {
     },
     isUserHighlighted(index) {
       return this.highlightSet.has(this.lineNumberFor(index));
+    },
+    isUserStrikethrough(index) {
+      return this.strikethroughSet.has(this.lineNumberFor(index));
     },
     // Returns the line number for the line at the given index in `content`.
     lineNumberFor(index) {
@@ -245,6 +257,12 @@ export default {
   .code-number {
     padding-left: $code-number-padding-left - $highlighted-border-width;
   }
+}
+
+.user-strikethrough {
+  text-decoration-line: line-through;
+  text-decoration-color: var(--color-figure-gray);
+  opacity: 0.85;
 }
 
 pre {

--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -12,7 +12,8 @@
   <div
     class="code-listing"
     :data-syntax="syntaxNameNormalized"
-    :class="{ 'single-line': syntaxHighlightedLines.length === 1 }"
+    :class="{ 'single-line': syntaxHighlightedLines.length === 1, 'is-wrapped': wrap > 0 }"
+    :style="wrapStyle"
   >
     <Filename
       v-if="fileName"
@@ -103,6 +104,14 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    wrap: {
+      type: Number,
+      required: true,
+    },
+    highlightedLines: {
+      type: Array,
+      required: true,
+    },
     startLineNumber: {
       type: Number,
       default: () => 1,
@@ -129,6 +138,22 @@ export default {
     copyableText() {
       return this.content.join('\n');
     },
+    highlightSet() {
+      const arr = this.highlightedLines || [];
+      return new Set(arr.map(Number).filter(n => Number.isFinite(n) && n > 0));
+    },
+    wrapStyle() {
+      const style = {};
+      if (this.wrap > 0) {
+        style.whiteSpace = 'pre-wrap';
+        style.wordBreak = 'break-word';
+        style.overflowWrap = 'anywhere';
+        style['--wrap-ch'] = String(this.wrap);
+      } else {
+        style.whiteSpace = 'pre';
+      }
+      return style;
+    },
   },
   watch: {
     content: {
@@ -138,7 +163,10 @@ export default {
   },
   methods: {
     isHighlighted(index) {
-      return this.highlightedLineNumbers.has(this.lineNumberFor(index));
+      const lineNumber = this.lineNumberFor(index);
+      const h1 = this.highlightedLineNumbers.has(lineNumber);
+      const h2 = this.highlightSet.has(lineNumber);
+      return (h1 || h2);
     },
     // Returns the line number for the line at the given index in `content`.
     lineNumberFor(index) {
@@ -247,6 +275,17 @@ code {
   &.single-line {
     border-radius: $large-border-radius;
   }
+}
+
+.is-wrapped pre,
+.is-wrapped code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.is-wrapped pre {
+  max-width: calc(var(--wrap-ch) * 1ch);
 }
 
 .container-general {

--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -41,7 +41,8 @@
         v-for="(line, index) in syntaxHighlightedLines"
       ><span
         :key="index"
-        :class="['code-line-container',{ highlighted: isHighlighted(index) }]"
+        :class="['code-line-container',{ highlighted: isHighlighted(index),
+                 'user-highlighted': isUserHighlighted(index) }]"
       ><span
         v-if="showLineNumbers"
         class="code-number"
@@ -163,10 +164,10 @@ export default {
   },
   methods: {
     isHighlighted(index) {
-      const lineNumber = this.lineNumberFor(index);
-      const h1 = this.highlightedLineNumbers.has(lineNumber);
-      const h2 = this.highlightSet.has(lineNumber);
-      return (h1 || h2);
+      return this.highlightedLineNumbers.has(this.lineNumberFor(index));
+    },
+    isUserHighlighted(index) {
+      return this.highlightSet.has(this.lineNumberFor(index));
     },
     // Returns the line number for the line at the given index in `content`.
     lineNumberFor(index) {
@@ -231,6 +232,15 @@ export default {
 .highlighted {
   background: var(--line-highlight, var(--color-code-line-highlight));
   border-left: $highlighted-border-width solid var(--color-code-line-highlight-border);
+
+  .code-number {
+    padding-left: $code-number-padding-left - $highlighted-border-width;
+  }
+}
+
+.user-highlighted {
+  background: var(--user-line-highlight, var(--color-user-code-line-highlight));
+  border-left: $highlighted-border-width solid var(--color-user-code-line-highlight-border);
 
   .code-number {
     padding-left: $code-number-padding-left - $highlighted-border-width;

--- a/src/components/ContentNode/CodeListing.vue
+++ b/src/components/ContentNode/CodeListing.vue
@@ -106,11 +106,11 @@ export default {
     },
     wrap: {
       type: Number,
-      required: true,
+      default: () => 0,
     },
     highlightedLines: {
       type: Array,
-      required: true,
+      default: () => [],
     },
     startLineNumber: {
       type: Number,

--- a/src/components/Tutorial/CodeTheme.vue
+++ b/src/components/Tutorial/CodeTheme.vue
@@ -84,6 +84,7 @@ export default {
         '--text': codeColors.text,
         '--background': codeColors.background,
         '--line-highlight': codeColors.lineHighlight,
+        '--user-line-highlight': codeColors.userLineHighlight,
         '--url': codeColors.commentURL,
         '--syntax-comment': codeColors.comment,
         '--syntax-quote': codeColors.comment,

--- a/src/styles/core/colors/_dark.scss
+++ b/src/styles/core/colors/_dark.scss
@@ -37,6 +37,7 @@
   --color-badge-default: var(--color-badge-dark-default);
   --color-button-background-active: #{dark-color(fill-blue)};
   --color-code-line-highlight: #{change-color(dark-color(figure-blue), $alpha: 0.08)};
+  --color-user-code-line-highlight: #{change-color(dark-color(figure-orange), $alpha: 0.32)};
   --color-dropdown-background: var(--color-dropdown-dark-background);
   --color-dropdown-border: var(--color-dropdown-dark-border);
   --color-dropdown-option-text: var(--color-dropdown-dark-option-text);

--- a/src/styles/core/colors/_light.scss
+++ b/src/styles/core/colors/_light.scss
@@ -77,6 +77,8 @@
   --color-code-collapsible-text: var(--color-figure-gray-secondary-alt);
   --color-code-line-highlight: #{change-color(light-color(figure-blue), $alpha: 0.08)};
   --color-code-line-highlight-border: var(--color-figure-blue);
+  --color-user-code-line-highlight: #{change-color(light-color(figure-orange), $alpha: 0.32)};
+  --color-user-code-line-highlight-border: var(--color-figure-orange);
   --color-code-plain: var(--color-figure-gray);
   --color-dropdown-background: #{transparentize(light-color(fill), 0.2)};
   --color-dropdown-border: #{light-color(fill-gray)};

--- a/tests/unit/components/ContentNode.spec.js
+++ b/tests/unit/components/ContentNode.spec.js
@@ -102,6 +102,9 @@ describe('ContentNode', () => {
       fileType: 'swift',
       code: ['foobar'],
       copyToClipboard: false,
+      wrap: 0,
+      highlightedLines: [],
+      strikethroughLines: [],
     };
 
     it('renders a `CodeListing`', () => {
@@ -113,6 +116,9 @@ describe('ContentNode', () => {
       expect(codeListing.props('fileType')).toBe(listing.fileType);
       expect(codeListing.props('content')).toEqual(listing.code);
       expect(codeListing.props('copyToClipboard')).toEqual(listing.copyToClipboard);
+      expect(codeListing.props('wrap')).toEqual(listing.wrap);
+      expect(codeListing.props('highlightedLines')).toEqual(listing.highlightedLines);
+      expect(codeListing.props('strikethroughLines')).toEqual(listing.strikethroughLines);
       expect(codeListing.isEmpty()).toBe(true);
     });
 

--- a/tests/unit/components/ContentNode/CodeListing.spec.js
+++ b/tests/unit/components/ContentNode/CodeListing.spec.js
@@ -301,4 +301,70 @@ describe('CodeListing', () => {
 
     expect(wrapper.classes()).toContain('single-line');
   });
+
+  it('does not wrap when wrap=0', async () => {
+    const wrapper = shallowMount(CodeListing, {
+      propsData: {
+        syntax: 'swift',
+        content: ['let foo = "bar"'],
+        wrap: 0,
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.classes()).not.toContain('is-wrapped');
+
+    const style = wrapper.attributes('style') || '';
+    expect(style).not.toMatch(/--wrap-ch:\s*\d+/);
+  });
+
+  it('wraps when wrap>0 and exposes the width in style', async () => {
+    const wrapper = shallowMount(CodeListing, {
+      propsData: {
+        syntax: 'swift',
+        content: ['let foo = "bar"'],
+        wrap: 80,
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.classes()).toContain('is-wrapped');
+
+    const style = wrapper.attributes('style') || '';
+    expect(style).toMatch(/--wrap-ch:\s*80\b/);
+  });
+
+  it('reacts when wrap changes', async () => {
+    const wrapper = shallowMount(CodeListing, {
+      propsData: {
+        syntax: 'swift',
+        content: ['let foo = "bar"'],
+        wrap: 80,
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.classes()).toContain('is-wrapped');
+
+    let style = wrapper.attributes('style') || '';
+    expect(style).toMatch(/--wrap-ch:\s*80\b/);
+
+    await wrapper.setProps({ wrap: 0 });
+    style = wrapper.attributes('style') || '';
+    expect(wrapper.classes()).not.toContain('is-wrapped');
+    expect(style).not.toMatch(/--wrap-ch:\s*\d+/);
+  });
+
+  it('treats negative wrap as no-wrap', async () => {
+    const wrapper = shallowMount(CodeListing, {
+      propsData: {
+        syntax: 'swift',
+        content: ['let foo = "bar"'],
+        wrap: -5,
+      },
+    });
+    await flushPromises();
+
+    expect(wrapper.classes()).not.toContain('is-wrapped');
+  });
 });

--- a/tests/unit/components/ContentNode/CodeListing.spec.js
+++ b/tests/unit/components/ContentNode/CodeListing.spec.js
@@ -97,6 +97,76 @@ describe('CodeListing', () => {
     });
   });
 
+  it('highlights the correct lines from highlightedLines', async () => {
+    const content = ['a', 'b', 'c', 'd', 'e'];
+    const highlightedLines = [1, 3];
+
+    const wrapper = shallowMount(CodeListing, {
+      propsData: {
+        content,
+        highlightedLines,
+        showLineNumbers: true,
+      },
+    });
+
+    await flushPromises();
+
+    const pre = wrapper.find('pre');
+    expect(pre.exists()).toBe(true);
+
+    const codeLineContainers = wrapper.findAll('span.code-line-container');
+    expect(codeLineContainers.length).toBe(content.length);
+
+    content.forEach((line, index) => {
+      const codeLineContainer = codeLineContainers.at(index);
+      const shouldBeHighlighted = highlightedLines.includes(index + 1);
+
+      const codeNumber = codeLineContainer.find('.code-number');
+
+      expect(codeNumber.attributes('data-line-number')).toBe(`${index + 1}`);
+
+      const codeLine = codeLineContainer.find('.code-line');
+      expect(codeLine.text()).toBe(line);
+
+      expect(codeLineContainer.classes('user-highlighted')).toBe(shouldBeHighlighted);
+    });
+  });
+
+  it('strikes through the correct lines from strikethroughLines', async () => {
+    const content = ['a', 'b', 'c', 'd', 'e'];
+    const strikethroughLines = [1, 3];
+
+    const wrapper = shallowMount(CodeListing, {
+      propsData: {
+        content,
+        strikethroughLines,
+        showLineNumbers: true,
+      },
+    });
+
+    await flushPromises();
+
+    const pre = wrapper.find('pre');
+    expect(pre.exists()).toBe(true);
+
+    const codeLineContainers = wrapper.findAll('span.code-line-container');
+    expect(codeLineContainers.length).toBe(content.length);
+
+    content.forEach((line, index) => {
+      const codeLineContainer = codeLineContainers.at(index);
+      const shouldBeStriked = strikethroughLines.includes(index + 1);
+
+      const codeNumber = codeLineContainer.find('.code-number');
+
+      expect(codeNumber.attributes('data-line-number')).toBe(`${index + 1}`);
+
+      const codeLine = codeLineContainer.find('.code-line');
+      expect(codeLine.text()).toBe(line);
+
+      expect(codeLineContainer.classes('user-strikethrough')).toBe(shouldBeStriked);
+    });
+  });
+
   it('syntax highlights code for Swift', async () => {
     const wrapper = shallowMount(CodeListing, {
       propsData: {


### PR DESCRIPTION
## Summary

This PR implements new code block options for line highlighting, line striking, and line wrapping. When the `enable-experimental-code-block` flag is enabled, code listings will have access to `highlight`, `strikeout`, and `wrap` properties forwarded in the render JSON.

### User Experience

- Lines listed in `highlight` appear with a fluorescent orange highlight overlay.
- Lines listed in `strikeout` appear with a strikethrough line.
- When `wrap` is present and greater than 0, code lines are soft-wrapped near the specified width.
- These options can be combined in the same code block.

### Implementation Overview

- Reads `highlight: [Int]?`, `strikeout: [Int]?`, and `wrap: Int?` from `RenderBlockContent.codeListing`
- Applies highlighting and strikethrough per line
- Applies wrapping and line layout to the specified width per code block container

## Dependencies

This PR depends on associated changes in `swift-docc` to actually render and handle the highlight, strikeout, and wrap options.

## Testing

### Setup
Use the additional-metadata branches for `swift-docc` and `swift-docc-render` with the new `highlight`, `strikeout`, and `wrap` changes.
Rebuild documentation using `swift-docc` and the feature flag `enable-experimental-code-block`. Serve it using a local build of `swift-docc-render`.

### How to Test
1. In any code listing using ``` or by adding a code listing, add the `highlight`, `strikeout` and/or `wrap` options after the language (optionally) like this:

``````
﻿```swift, highlight=[1,3,4], strikeout=[2, 3], wrap=40
﻿let a = 1
﻿let b = 2
﻿let c = 3
﻿let d = 4
﻿```
``````

2. Confirm highlighted lines and struck-through lines have the correct styling and that wrapping is styled with the configured width.
3. Confirm these options can be combined and are styled correctly.
4. Verify the above behavior with and without a language token in the language line.

## Checklist
- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary

These new options looks like the below:
<img width="1491" height="224" alt="Line highlighting, striking, and wrapping in dark theme" src="https://github.com/user-attachments/assets/9be4738f-f779-4361-81c2-4c07f92971fc" />
<img width="1459" height="219" alt="Line highlighting, striking, and wrapping in light theme" src="https://github.com/user-attachments/assets/059680a5-1293-439a-8c87-ad7d7cc69d8f" />

Compared to without these options:
<img width="1343" height="199" alt="Code example without options in dark theme" src="https://github.com/user-attachments/assets/76b1b881-0e6d-47e6-86ab-60c6ffd47131" />
