### PR TITLE
[Regression] border-width-right is hardcoded to 0 for asides

### DIFF
--- a/src/components/ContentNode/Aside.vue
+++ b/src/components/ContentNode/Aside.vue
@@ -53,13 +53,10 @@ aside {
   break-inside: avoid;
   border-radius: var(--aside-border-radius, $border-radius);
   border-style: var(--aside-border-style, solid);
-  /*border-width: var(--aside-border-width,
-    $aside-width-border
-    $aside-width-border
-    $aside-width-border
-    $aside-width-left-border);*/
-  border-block-width: $aside-width-border;
-  border-inline-width: $aside-width-left-border 0;
+  border-block-width: var(--aside-border-width-block, $aside-width-border);
+  border-inline-width: var(--aside-border-width-inline,
+    $aside-width-left-border
+    $aside-width-border);
   padding: rem(16px);
   text-align: start;
 


### PR DESCRIPTION
Bug/issue #, if applicable: 159716327

## Summary

Fixes a regression introduced with #954 where the right border-width for asides is always hardcoded to 0 now.

While this doesn't have a major impact on the visuals since there is no right-border for asides normally, the variable that was previous used allowed for this border-width to be customized and should be re-introduced.

## Testing

Steps:
1. Load any page with an aside and verify that the borders still look the same
2. Modify the `$aside-border-width` variable and verify that the value is utilized on the right-hand-side of aside elements

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
