### PR TITLE
Support `availableLanguages` key

### DIFF
--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -179,7 +179,7 @@ export default {
       this.store.setReferences(references);
     },
     'metadata.availableLocales': function availableLocalesWatcher(availableLocales) {
-      AppStore.setAvailableLocales(availableLocales);
+      AppStore.setAvailableLocales(this.metadata?.availableLanguages ?? availableLocales);
     },
     'metadata.availableLanguages': function availableLanguagesWatcher(availableLanguages) {
       AppStore.setAvailableLocales(availableLanguages);

--- a/src/components/Article.vue
+++ b/src/components/Article.vue
@@ -167,7 +167,9 @@ export default {
     },
   },
   created() {
-    AppStore.setAvailableLocales(this.metadata.availableLocales);
+    AppStore.setAvailableLocales(
+      this.metadata.availableLanguages ?? this.metadata.availableLocales,
+    );
     this.store.reset();
     this.store.setReferences(this.references);
   },
@@ -178,6 +180,9 @@ export default {
     },
     'metadata.availableLocales': function availableLocalesWatcher(availableLocales) {
       AppStore.setAvailableLocales(availableLocales);
+    },
+    'metadata.availableLanguages': function availableLanguagesWatcher(availableLanguages) {
+      AppStore.setAvailableLocales(availableLanguages);
     },
   },
   SectionKind,

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -739,7 +739,7 @@ export default {
       AppStore.setAvailableLocales(availableLanguages);
     },
     availableLocales(availableLocales) {
-      AppStore.setAvailableLocales(availableLocales);
+      AppStore.setAvailableLocales(this.availableLanguages ?? availableLocales);
     },
   },
 };

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -404,6 +404,10 @@ export default {
       required: false,
       validator: v => Object.prototype.hasOwnProperty.call(StandardColors, v),
     },
+    availableLanguages: {
+      type: Array,
+      required: false,
+    },
     availableLocales: {
       type: Array,
       required: false,
@@ -624,6 +628,7 @@ export default {
           conformance,
           hasNoExpandedDocumentation,
           modules,
+          availableLanguages,
           availableLocales,
           platforms,
           required: isRequirement = false,
@@ -666,6 +671,7 @@ export default {
         downloadNotAvailableSummary,
         diffAvailability,
         hasNoExpandedDocumentation,
+        availableLanguages,
         availableLocales,
         hierarchy,
         role,
@@ -717,7 +723,7 @@ export default {
       });
     }
 
-    AppStore.setAvailableLocales(this.availableLocales || []);
+    AppStore.setAvailableLocales(this.availableLanguages ?? this.availableLocales);
     this.store.reset();
     this.store.setReferences(this.references);
   },
@@ -728,6 +734,9 @@ export default {
     // update the references in the store, in case they update, but the component is not re-created
     references(references) {
       this.store.setReferences(references);
+    },
+    availableLanguages(availableLanguages) {
+      AppStore.setAvailableLocales(availableLanguages);
     },
     availableLocales(availableLocales) {
       AppStore.setAvailableLocales(availableLocales);

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -135,7 +135,9 @@ export default {
     },
   },
   created() {
-    AppStore.setAvailableLocales(this.metadata.availableLocales);
+    AppStore.setAvailableLocales(
+      this.metadata.availableLanguages ?? this.metadata.availableLocales,
+    );
     this.store.reset();
     this.store.setReferences(this.references);
   },
@@ -146,6 +148,9 @@ export default {
     },
     'metadata.availableLocales': function availableLocalesWatcher(availableLocales) {
       AppStore.setAvailableLocales(availableLocales);
+    },
+    'metadata.availableLanguages': function availableLanguagesWatcher(availableLanguages) {
+      AppStore.setAvailableLocales(availableLanguages);
     },
   },
   mounted() {

--- a/src/components/Tutorial.vue
+++ b/src/components/Tutorial.vue
@@ -147,7 +147,7 @@ export default {
       this.store.setReferences(references);
     },
     'metadata.availableLocales': function availableLocalesWatcher(availableLocales) {
-      AppStore.setAvailableLocales(availableLocales);
+      AppStore.setAvailableLocales(this.metadata?.availableLanguages ?? availableLocales);
     },
     'metadata.availableLanguages': function availableLanguagesWatcher(availableLanguages) {
       AppStore.setAvailableLocales(availableLanguages);

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -113,7 +113,7 @@ export default {
       this.store.setReferences(references);
     },
     'metadata.availableLocales': function availableLocalesWatcher(availableLocales) {
-      AppStore.setAvailableLocales(availableLocales);
+      AppStore.setAvailableLocales(this.metadata?.availableLanguages ?? availableLocales);
     },
     'metadata.availableLanguages': function availableLanguagesWatcher(availableLanguages) {
       AppStore.setAvailableLocales(availableLanguages);

--- a/src/components/TutorialsOverview.vue
+++ b/src/components/TutorialsOverview.vue
@@ -101,7 +101,9 @@ export default {
     };
   },
   created() {
-    AppStore.setAvailableLocales(this.metadata.availableLocales);
+    AppStore.setAvailableLocales(
+      this.metadata.availableLanguages ?? this.metadata.availableLocales,
+    );
     this.store.reset();
     this.store.setReferences(this.references);
   },
@@ -112,6 +114,9 @@ export default {
     },
     'metadata.availableLocales': function availableLocalesWatcher(availableLocales) {
       AppStore.setAvailableLocales(availableLocales);
+    },
+    'metadata.availableLanguages': function availableLanguagesWatcher(availableLanguages) {
+      AppStore.setAvailableLocales(availableLanguages);
     },
   },
 };

--- a/tests/unit/components/Article.spec.js
+++ b/tests/unit/components/Article.spec.js
@@ -17,6 +17,7 @@ import Hero from 'docc-render/components/Article/Hero.vue';
 import NavigationBar from 'docc-render/components/Tutorial/NavigationBar.vue';
 import TopicStore from 'docc-render/stores/TopicStore';
 import { PortalTarget } from 'portal-vue';
+import AppStore from 'docc-render/stores/AppStore';
 
 const { SectionKind } = Article;
 
@@ -198,6 +199,36 @@ describe('Article', () => {
       },
     });
     expect(wrapper.text()).toContain('Above Hero Text');
+  });
+
+  it('sets available langs/locales', async () => {
+    const locales = ['en-US', 'ja-JP'];
+    const langs = ['en', 'jp'];
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLocales: locales,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(locales);
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLanguages: langs,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(langs);
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLanguages: langs,
+        availableLocales: locales,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(langs);
   });
 });
 

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -20,6 +20,7 @@ import OnThisPageNav from '@/components/OnThisPageNav.vue';
 import OnThisPageStickyContainer
   from '@/components/DocumentationTopic/OnThisPageStickyContainer.vue';
 import Declaration from '@/components/DocumentationTopic/PrimaryContent/Declaration.vue';
+import AppStore from '@/stores/AppStore';
 
 const { ON_THIS_PAGE_CONTAINER_BREAKPOINT } = DocumentationTopic.constants;
 
@@ -1173,6 +1174,23 @@ describe('DocumentationTopic', () => {
     });
     expect(mockStore.setReferences).toHaveBeenCalledTimes(2);
     expect(mockStore.setReferences).toHaveBeenCalledWith(newReferences);
+  });
+
+  it('sets available languages/locales', async () => {
+    const locales = ['en-US', 'ja-JP'];
+    const langs = ['en', 'jp'];
+
+    await wrapper.setProps({ availableLocales: locales });
+    expect(AppStore.state.availableLocales).toEqual(locales);
+
+    await wrapper.setProps({ availableLanguages: langs });
+    expect(AppStore.state.availableLocales).toEqual(langs);
+
+    await wrapper.setProps({
+      availableLanguages: langs,
+      availableLocales: locales,
+    });
+    expect(AppStore.state.availableLocales).toEqual(langs);
   });
 
   it('calls `store.updateReferences` when `indexState.includedArchiveIdentifiers` changes', async () => {

--- a/tests/unit/components/Tutorial.spec.js
+++ b/tests/unit/components/Tutorial.spec.js
@@ -15,6 +15,7 @@ import Tutorial from 'docc-render/components/Tutorial.vue';
 import SectionList from 'docc-render/components/Tutorial/SectionList.vue';
 import NavigationBar from 'docc-render/components/Tutorial/NavigationBar.vue';
 import TopicStore from 'docc-render/stores/TopicStore';
+import AppStore from 'docc-render/stores/AppStore';
 
 const { Section, BreakpointEmitter, PortalTarget } = Tutorial.components;
 
@@ -238,6 +239,36 @@ describe('Tutorial', () => {
     const target = wrapper.findComponent(PortalTarget);
     expect(target.exists()).toBe(true);
     expect(target.props()).toHaveProperty('name', 'modal-destination');
+  });
+
+  it('sets available langs/locales', async () => {
+    const locales = ['en-US', 'ja-JP'];
+    const langs = ['en', 'jp'];
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLocales: locales,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(locales);
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLanguages: langs,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(langs);
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLanguages: langs,
+        availableLocales: locales,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(langs);
   });
 });
 

--- a/tests/unit/components/TutorialsOverview.spec.js
+++ b/tests/unit/components/TutorialsOverview.spec.js
@@ -10,6 +10,7 @@
 
 import { shallowMount } from '@vue/test-utils';
 import TutorialsOverview from 'docc-render/components/TutorialsOverview.vue';
+import AppStore from 'docc-render/stores/AppStore';
 
 const {
   Hero,
@@ -117,5 +118,35 @@ describe('TutorialsOverview', () => {
       slots: { 'above-hero': 'Above Hero Content' },
     });
     expect(wrapper.text()).toContain('Above Hero Content');
+  });
+
+  it('sets available langs/locales', async () => {
+    const locales = ['en-US', 'ja-JP'];
+    const langs = ['en', 'jp'];
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLocales: locales,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(locales);
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLanguages: langs,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(langs);
+
+    await wrapper.setProps({
+      metadata: {
+        ...propsData.metadata,
+        availableLanguages: langs,
+        availableLocales: locales,
+      },
+    });
+    expect(AppStore.state.availableLocales).toEqual(langs);
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: 149303906

## Summary

The `availableLocales` Render JSON key may be renamed to `availableLanguages` going forward, although we still want to support both keys for maximum compatibility with older JSON (preferring the new one if both are present for some reason).

## Testing

Steps:
1. Verify that the key `availableLanguages` can be used in place of `availableLocales`

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [X] Added tests
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
