### PR TITLE
[Regression] Fix `@Links` layout rendering for grid styles

### DIFF
--- a/src/components/ContentNode/Column.vue
+++ b/src/components/ContentNode/Column.vue
@@ -48,7 +48,7 @@ export default {
 .column {
   display: flex;
   flex-direction: column;
-  align-items: var(--col-alignment, flex-start);
+  align-items: var(--col-alignment, normal);
   grid-column: span var(--col-span);
   min-width: 0;
   @include breakpoint(small) {


### PR DESCRIPTION
Bug/issue #, if applicable: 179413082

## Summary

#1018 introduces a regression for the way that columns are rendered within the `@Links` DocC directive when the visual style is either `compactGrid` or `detailedGrid`.

This happens because the new `align-items` property has a default of `flex-start`, which has unintended consequences for the way that the `TopicsLinkCardGrid` component composes the `Column` component without setting an explicit alignment.

By changing the default value from `flex-start` to `normal`, we can fix the unexpected rendering for the `@Links` directive without impacting the new enhancement to support the alignment property for `@Column`.

## Testing

Steps:
1. Create or test some DocC content that utilizes `@PageImage` and `@Links(visualStyle: detailedGrid)`
2. Verify that the grid items rendered for the links continue to look the way they should, with images appearing in a fixed grid pattern.
3. Verify that other content using `@Column(alignment: leading|center|trailing)` still renders with the expected alignment for its items as implemented in #1018 

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [ ] Added tests (CSS-only change)
- [X] Ran `npm test`, and it succeeded
- [X] Updated documentation if necessary
