### PR TITLE
style: enable smooth scrolling for anchor links

### DIFF
--- a/src/styles/base/_reset.scss
+++ b/src/styles/base/_reset.scss
@@ -18,6 +18,10 @@ html {
   // enough that it does not actually exceed the breakpoint height.
   background-color: var(--colors-text-background, var(--color-text-background));
   height: 100%;
+  // Enable smooth scrolling for anchor links unless reduced motion is preferred.
+  @media (prefers-reduced-motion: no-preference) {
+    scroll-behavior: smooth;
+  }
 }
 
 //============================================================

--- a/src/styles/base/_reset.scss
+++ b/src/styles/base/_reset.scss
@@ -18,10 +18,6 @@ html {
   // enough that it does not actually exceed the breakpoint height.
   background-color: var(--colors-text-background, var(--color-text-background));
   height: 100%;
-  // Enable smooth scrolling for anchor links unless reduced motion is preferred.
-  @media (prefers-reduced-motion: no-preference) {
-    scroll-behavior: smooth;
-  }
 }
 
 //============================================================

--- a/src/utils/router-utils.js
+++ b/src/utils/router-utils.js
@@ -63,7 +63,17 @@ export async function scrollBehavior(to, from, savedPosition) {
     const offset = baseNavOffset + apiChangesNavHeight + getExtraScrollOffset(to);
 
     const y = process.env.VUE_APP_TARGET === 'ide' ? 0 : offset;
-    return { selector: cssEscapeTopicIdHash(hash), offset: { x: 0, y } };
+    const position = {
+      selector: cssEscapeTopicIdHash(hash),
+      offset: { x: 0, y },
+    };
+    if (typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
+      return {
+        ...position,
+        behavior: 'smooth',
+      };
+    }
+    return position;
   }
   if (areEquivalentLocations(to, from)) {
     // Do not change the scroll position if the location hasn't changed

--- a/tests/unit/utils/router-utils.spec.js
+++ b/tests/unit/utils/router-utils.spec.js
@@ -60,6 +60,16 @@ describe('router-utils', () => {
 
     beforeEach(() => {
       process.env.VUE_APP_TARGET = appTarget;
+      window.matchMedia = jest.fn().mockReturnValue({
+        matches: true,
+        media: '(prefers-reduced-motion: no-preference)',
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      });
     });
 
     it('resolves with the saved position', async () => {
@@ -83,7 +93,11 @@ describe('router-utils', () => {
     it('resolves with a selector and `y:0` offset if passed `hash` but in IDE target', async () => {
       process.env.VUE_APP_TARGET = 'ide';
       const resolved = await scrollBehavior(routeFoo, routeBar);
-      expect(resolved).toEqual({ selector: routeFoo.hash, offset: { x: 0, y: 0 } });
+      expect(resolved).toEqual({
+        selector: routeFoo.hash,
+        offset: { x: 0, y: 0 },
+        behavior: 'smooth',
+      });
     });
 
     it('resolves with one nav height offset if passed `hash` but no API `changes` enabled', async () => {
@@ -93,6 +107,7 @@ describe('router-utils', () => {
       expect(resolved).toEqual({
         selector: routeDocsNoChanges.hash,
         offset: { x: 0, y: baseNavHeight + EXTRA_DOCUMENTATION_OFFSET },
+        behavior: 'smooth',
       });
     });
 
@@ -105,6 +120,7 @@ describe('router-utils', () => {
       expect(resolved).toEqual({
         selector: routeDocsNoChanges.hash,
         offset: { x: 0, y: baseNavHeightSmallBreakpoint + EXTRA_DOCUMENTATION_OFFSET },
+        behavior: 'smooth',
       });
 
       window.innerWidth = innerWidth;
@@ -117,6 +133,26 @@ describe('router-utils', () => {
       expect(resolved).toEqual({
         selector: routeDocsNoChanges.hash,
         offset: { x: 0, y: baseNavHeight * 2 + EXTRA_DOCUMENTATION_OFFSET },
+        behavior: 'smooth',
+      });
+    });
+
+    it('does not resolve with smooth behavior if reduced motion is preferred', async () => {
+      window.matchMedia = jest.fn().mockReturnValue({
+        matches: false,
+        media: '(prefers-reduced-motion: no-preference)',
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      });
+      const routeDocsNoChanges = createRoute(documentationTopicName, {}, 'bar');
+      const resolved = await scrollBehavior(routeDocsNoChanges, routeBar);
+      expect(resolved).toEqual({
+        selector: routeDocsNoChanges.hash,
+        offset: { x: 0, y: baseNavHeight + EXTRA_DOCUMENTATION_OFFSET },
       });
     });
 


### PR DESCRIPTION
Bug/issue #, if applicable: #985

## Summary

This PR addresses the abrupt page jump that occurs when navigating via anchor links across documentation pages, such as clicking on specific section headers, table of contents items, or direct sub-page indexing links.

### Expected User Experience

Instead of an instantaneous and jarring snap down the viewport, the page now smoothly glides to the target element.

This provides better visual continuity and a more polished user experience, aligned with modern Apple design and web standards.

### Implementation Overview

Added `scroll-behavior: smooth` to the global `html` element within:

```scss
src/styles/base/_reset.scss
```

To ensure accessibility compliance, this animation is explicitly wrapped inside a `@media (prefers-reduced-motion: no-preference)` media query.

This guarantees that users with system-level reduced motion preferences enabled will keep the default immediate jump behavior instead of receiving an animated scroll.

## Dependencies

None.

## Testing

This presentational change has been verified by compiling the production asset pipeline and validating the compiled stylesheet behavior on a localized static production server.

### Steps

1. Run the production build script to ensure the SCSS asset pipeline compiles cleanly without syntax regressions:

   ```bash
   npm run build
   ```

2. Serve the generated static artifacts locally to bypass environment-specific Node/proxy constraints:

   ```bash
   npx serve dist
   ```

3. Open the local server URL provided in the terminal.

   Typically:

   ```text
   http://localhost:3000
   ```

4. Since the application mounts on the root directory without a default documentation bundle loaded, open the browser Developer Tools.

   You can do this with:

   ```text
   F12 / Inspect
   ```

5. Paste the following snippet into the Console to simulate an anchor-linked document structure:

   ```javascript
   document.body.innerHTML = `
     <div style="padding: 40px; font-family: sans-serif; min-height: 3000px; background: white;">
       <a href="#test-scroll" style="position: fixed; top: 20px; left: 20px; background: #0066cc; color: white; padding: 12px 24px; border-radius: 8px; font-weight: bold; text-decoration: none; box-shadow: 0 4px 12px rgba(0,0,0,0.15);">
         👉 Click to Verify Smooth Scroll
       </a>

       <div style="height: 1500px; margin: 40px 0; background: #f5f5f7; border: 2px dashed #ccc; display: flex; align-items: center; justify-content: center; color: #86868b;">
         (Simulated Documentation Content Viewport)
       </div>

       <h2 id="test-scroll" style="font-size: 32px; color: #1d1d1f; margin-top: 50px; padding-top: 20px; border-top: 2px solid #eee;">
         📍 Target Destination Reached Successfully
       </h2>
     </div>
   `;
   ```

6. Click the rendered blue action button:

   ```text
   👉 Click to Verify Smooth Scroll
   ```

7. Verify that the viewport smoothly transitions down to the target header element.

### Optional Accessibility Verification

1. Enable **Reduce Motion** in macOS System Settings.

2. Click the rendered blue action button again.

3. Verify that the behavior cleanly falls back to an instantaneous viewport jump.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [X] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
- **Reason:** Not applicable. The implementation utilizes native web standards and does not alter configuration files, public configuration flags, or custom design tokens.