### PR TITLE
[6.4] Add locale fallback with redirect for 404 pages

### DIFF
--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -13,6 +13,8 @@ import {
   queryStringForParams, areEquivalentLocations, getAbsoluteUrl,
 } from 'docc-render/utils/url-helper';
 import emitWarningForSchemaVersionMismatch from 'docc-render/utils/schema-version-check';
+import { defaultLocale } from 'theme/lang/index';
+import { localeIsValid } from 'docc-render/utils/i18n-utils';
 import RedirectError from 'docc-render/errors/RedirectError';
 import FetchError from 'docc-render/errors/FetchError';
 
@@ -95,6 +97,14 @@ export async function fetchDataForRouteEnter(to, from, next) {
     }
 
     if (error.status && error.status === 404) {
+      // Destructure the locale out of the route params, leaving the rest.
+      const { locale, ...paramsWithoutLocale } = to.params ?? {};
+      if (locale && locale !== defaultLocale && localeIsValid(locale)) {
+        // Call `next` with the same route but without the locale param,
+        // redirecting to the non-localized version of the route.
+        next({ ...to, params: paramsWithoutLocale });
+        return null;
+      }
       // route to 404 page if missing data, but not in IDE build
       next({
         name: 'not-found',

--- a/tests/unit/utils/data.spec.js
+++ b/tests/unit/utils/data.spec.js
@@ -34,7 +34,7 @@ const goodFetchResponse = {
   ok: true,
   json: () => Promise.resolve({ foobar: 'foobar' }),
 };
-const notFoundFetchResposne = {
+const notFoundFetchResponse = {
   ok: false,
   status: 404,
 };
@@ -155,6 +155,11 @@ describe('fetchDataForRouteEnter', () => {
     path: '/tutorials/augmented-reality/tutorials',
     params: { locale: defaultLocale },
   };
+  const localizedTo = {
+    name: 'technology-tutorials-locale',
+    path: '/zh-CN/tutorials/augmented-reality/tutorials',
+    params: { locale: 'zh-CN' },
+  };
   const from = {};
   const next = jest.fn();
 
@@ -213,12 +218,39 @@ describe('fetchDataForRouteEnter', () => {
   });
 
   it('calls the `next` fn with a not-found route for 404s', async () => {
-    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResposne);
+    window.fetch = jest.fn().mockImplementation(() => notFoundFetchResponse);
 
     await fetchDataForRouteEnter(to, from, next);
     await expect(next).toHaveBeenCalledWith({
       name: 'not-found',
       params: ['/tutorials/augmented-reality/tutorials'],
+    });
+
+    window.fetch.mockRestore();
+  });
+
+  it('redirects to the default locale path when a localized page returns 404', async () => {
+    window.fetch = jest.fn().mockImplementationOnce(() => notFoundFetchResponse);
+
+    await fetchDataForRouteEnter(localizedTo, from, next);
+    expect(window.fetch).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith({ ...localizedTo, params: {} });
+
+    window.fetch.mockRestore();
+  });
+
+  it('routes to 404 page when a page with an unsupported locale param returns 404', async () => {
+    window.fetch = jest.fn().mockImplementationOnce(() => notFoundFetchResponse);
+
+    const fakeLocaleTo = {
+      name: 'technology-tutorials-locale',
+      path: '/fakelocale/tutorials/augmented-reality/tutorials',
+      params: { locale: 'fakelocale' },
+    };
+    await fetchDataForRouteEnter(fakeLocaleTo, from, next);
+    expect(next).toHaveBeenCalledWith({
+      name: 'not-found',
+      params: [fakeLocaleTo.path],
     });
 
     window.fetch.mockRestore();


### PR DESCRIPTION
**Explanation**: Adjusts routing behavior to fallback to default locale when translation is unavailable
**Scope**: Impacts navigation to locale prefixed routes and data fetching
**Issue**: rdar://172836734
**Risk**: Medium, small logic change that impact every page navigation
**Testing**: Updated unit tests, manually checked for regressions with navigation of documentation archives
**Reviewer**: @mportiz08
**Original PR**: #1003