### PR TITLE
[6.4] Add extension points to documentation components

### DIFF
--- a/src/components/ContentNode/Aside.vue
+++ b/src/components/ContentNode/Aside.vue
@@ -10,7 +10,9 @@
 
 <template>
   <aside :class="kind" :aria-label="kind">
-    <p class="label">{{ name || $t(label) }}</p>
+    <slot name="label">
+      <p class="label">{{ name || $t(label) }}</p>
+    </slot>
     <slot />
   </aside>
 </template>

--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -61,6 +61,7 @@
           :class="{ 'minimized-abstract': enableMinimized }"
           :content="abstract"
         />
+        <slot name="below-abstract" />
         <div v-if="sampleCodeDownload">
           <DownloadButton
             class="sample-download"

--- a/tests/unit/components/ContentNode/Aside.spec.js
+++ b/tests/unit/components/ContentNode/Aside.spec.js
@@ -59,6 +59,20 @@ describe('Aside', () => {
     expect(label.text()).toBe('Custom Name');
   });
 
+  it('renders a default label slot that can be overridden with custom content', () => {
+    const wrapper = shallowMount(Aside, {
+      propsData: {
+        kind: 'note',
+      },
+      slots: {
+        label: '<span class="custom-label">My Label</span>',
+        default: '<p>content</p>',
+      },
+    });
+    expect(wrapper.find('.label').exists()).toBe(false);
+    expect(wrapper.find('.custom-label').text()).toBe('My Label');
+  });
+
   it('renders slot content', () => {
     const wrapper = shallowMount(Aside, {
       propsData: {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -1124,6 +1124,19 @@ describe('DocumentationTopic', () => {
     expect(wrapper.find('.above-hero-content').exists()).toBe(true);
   });
 
+  it('renders content in the `below-abstract` slot', () => {
+    wrapper = shallowMount(DocumentationTopic, {
+      propsData,
+      slots: {
+        'below-abstract': '<div class="below-abstract">Below Abstract Content</div>',
+      },
+      provide: {
+        store: mockStore,
+      },
+    });
+    expect(wrapper.findComponent(DocumentationHero).find('.below-abstract').exists()).toBe(true);
+  });
+
   it('renders `OnThisPageNav` component, if enabled via prop', async () => {
     expect(wrapper.findComponent(OnThisPageNav).exists()).toBe(false);
     expect(wrapper.findComponent(OnThisPageStickyContainer).exists()).toBe(false);


### PR DESCRIPTION
**Explanation**: Adds extension points to 2 documentation components
**Scope**: Added slot below documentation abstract, added slot for aside title
**Issue**: rdar://176906827
**Risk**: Low, only added slots. No change to existing behavior—just extension points that can be overridden
**Testing**: Added unit tests, manually checked that there are no visual regressions
**Reviewer**: @mportiz08
**Original PRs**: 
* #1017 
* #1019 