### PR TITLE
Preserve the active locale when switching language variant

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -185,6 +185,7 @@ import SymbolKind from 'docc-render/constants/SymbolKind';
 import metadata from 'theme/mixins/metadata';
 import { buildUrl } from 'docc-render/utils/url-helper';
 import { normalizeRelativePath } from 'docc-render/utils/assets';
+import { pathWithLocale } from 'docc-render/utils/i18n-utils';
 import { last } from 'docc-render/utils/arrays';
 
 import AppStore from 'docc-render/stores/AppStore';
@@ -719,7 +720,7 @@ export default {
 
       this.$nextTick().then(() => {
         this.$router.replace({
-          path: normalizeRelativePath(this.objcPath),
+          path: pathWithLocale(this.objcPath, this.$route.params?.locale),
           query: {
             ...query,
             language: Language.objectiveC.key.url,

--- a/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
+++ b/src/components/DocumentationTopic/DocumentationNav/LanguageToggle.vue
@@ -84,7 +84,7 @@
 
 <script>
 import { waitFrames } from 'docc-render/utils/loading';
-import { normalizeRelativePath } from 'docc-render/utils/assets';
+import { pathWithLocale } from 'docc-render/utils/i18n-utils';
 import Language from 'docc-render/constants/Language';
 import throttle from 'docc-render/utils/throttle';
 import NavMenuItemBase from 'docc-render/components/NavMenuItemBase.vue';
@@ -165,7 +165,9 @@ export default {
       return {
         // make sure we dont loose any extra query params on the way
         query: { ...this.$route.query, language },
-        path: this.isCurrentPath(route.path) ? null : normalizeRelativePath(route.path),
+        path: this.isCurrentPath(route.path)
+          ? null
+          : pathWithLocale(route.path, this.$route.params?.locale),
       };
     },
     async pushRoute(route) {

--- a/src/components/DocumentationTopic/Summary/LanguageSwitcher.vue
+++ b/src/components/DocumentationTopic/Summary/LanguageSwitcher.vue
@@ -34,7 +34,7 @@
 
 <script>
 import { buildUrl } from 'docc-render/utils/url-helper';
-import { normalizeRelativePath } from 'docc-render/utils/assets';
+import { pathWithLocale } from 'docc-render/utils/i18n-utils';
 import Language from 'docc-render/constants/Language';
 
 import LanguageSwitcherLink from './LanguageSwitcherLink.vue';
@@ -83,11 +83,11 @@ export default {
     objc: ({
       interfaceLanguage,
       objcPath,
-      $route: { query },
+      $route: { query, params = {} },
     }) => ({
       ...Language.objectiveC,
       active: Language.objectiveC.key.api === interfaceLanguage,
-      url: buildUrl(normalizeRelativePath(objcPath), {
+      url: buildUrl(pathWithLocale(objcPath, params.locale), {
         ...query,
         language: Language.objectiveC.key.url,
       }),
@@ -95,11 +95,11 @@ export default {
     swift: ({
       interfaceLanguage,
       swiftPath,
-      $route: { query },
+      $route: { query, params = {} },
     }) => ({
       ...Language.swift,
       active: Language.swift.key.api === interfaceLanguage,
-      url: buildUrl(normalizeRelativePath(swiftPath), {
+      url: buildUrl(pathWithLocale(swiftPath, params.locale), {
         ...query,
         language: undefined,
       }),

--- a/src/utils/i18n-utils.js
+++ b/src/utils/i18n-utils.js
@@ -11,6 +11,7 @@
 import locales from 'theme/lang/locales.json';
 import { defaultLocale } from 'theme/lang/index';
 import { updateLangTag } from 'docc-render/utils/metadata';
+import { normalizeRelativePath, pathJoin } from 'docc-render/utils/assets';
 
 const codeForSlug = locales.reduce((map, locale) => ({
   ...map,
@@ -44,6 +45,23 @@ export function getLocaleParam(slug) {
       locale: slug === defaultLocale ? undefined : slug,
     },
   };
+}
+
+/**
+ * Prefixes a path with the given locale slug, so that navigation stays within
+ * the current locale.
+ * @param {String} path - a path, with or without a leading slash
+ * @param {String} [locale] - the locale slug to prefix with
+ * @return {String}
+ */
+export function pathWithLocale(path, locale) {
+  if (!path) return path;
+  const normalizedPath = normalizeRelativePath(path);
+  // No prefix needed for the default locale (routes declare locale as optional).
+  if (!locale || locale === defaultLocale || !localeIsValid(locale)) {
+    return normalizedPath;
+  }
+  return pathJoin(['/', locale, normalizedPath]);
 }
 
 /**

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -1238,8 +1238,7 @@ describe('DocumentationTopic', () => {
       expect(mockStore.setReferences).toHaveBeenCalledWith(propsData.references);
     });
 
-    it('routes to the objc variant of a page if that is the preferred language', async () => {
-      const $route = { query: {} };
+    const mountWithObjcPreference = async ($route) => {
       const $router = { replace: jest.fn() };
       const store = {
         ...mockStore,
@@ -1249,16 +1248,26 @@ describe('DocumentationTopic', () => {
         },
       };
       wrapper = shallowMount(DocumentationTopic, {
-        mocks: {
-          $route,
-          $router,
-        },
+        mocks: { $route, $router },
         propsData,
         provide: { store },
       });
       await wrapper.vm.$nextTick();
+      return $router;
+    };
+
+    it('routes to the objc variant of a page if that is the preferred language', async () => {
+      const $router = await mountWithObjcPreference({ query: {} });
       expect($router.replace).toBeCalledWith({
         path: `/${propsData.languagePaths.occ[0]}`,
+        query: { language: Language.objectiveC.key.url },
+      });
+    });
+
+    it('preserves the current locale when routing to the objc variant', async () => {
+      const $router = await mountWithObjcPreference({ query: {}, params: { locale: 'es' } });
+      expect($router.replace).toBeCalledWith({
+        path: `/es/${propsData.languagePaths.occ[0]}`,
         query: { language: Language.objectiveC.key.url },
       });
     });

--- a/tests/unit/components/DocumentationTopic/DocumentationNav/LanguageToggle.spec.js
+++ b/tests/unit/components/DocumentationTopic/DocumentationNav/LanguageToggle.spec.js
@@ -283,6 +283,29 @@ describe('LanguageToggle', () => {
       });
   });
 
+  it('preserves the current locale in the path when switching languages', async () => {
+    const mocksWithLocale = {
+      ...mocks,
+      $route: {
+        path: '/ja-JP/documentation/foo',
+        params: { locale: 'ja-JP' },
+      },
+    };
+    wrapper = createWrapper(
+      { ...propsData, objcPath: 'documentation/bar' },
+      mocksWithLocale,
+    );
+
+    const link = wrapper.findComponent('.language-list-container').find('a.nav-menu-link');
+    link.trigger('click');
+    await flushPromises();
+    expect(mocks.$router.push)
+      .toHaveBeenCalledWith({
+        path: '/ja-JP/documentation/bar',
+        query: { language: Language.objectiveC.key.url },
+      });
+  });
+
   it('changes the model, if the interfaceLanguage changes', async () => {
     // assert proper language name is shown
     expect(wrapper.findComponent('.current-language').text()).toBe(Language.swift.name);

--- a/tests/unit/components/DocumentationTopic/Summary/LanguageSwitcher.spec.js
+++ b/tests/unit/components/DocumentationTopic/Summary/LanguageSwitcher.spec.js
@@ -19,10 +19,6 @@ const {
   Title,
 } = LanguageSwitcher.components;
 
-jest.mock('docc-render/utils/assets', () => ({
-  normalizeRelativePath: jest.fn(name => `/${name}`),
-}));
-
 describe('LanguageSwitcher', () => {
   let wrapper;
 
@@ -126,6 +122,22 @@ describe('LanguageSwitcher', () => {
 
     expect(links.at(0).props('url')).toEqual(null);
     expect(links.at(1).props('url')).toBe('/documentation/foo?language=objc');
+  });
+
+  it('preserves the current locale in the generated links', () => {
+    wrapper = shallowMount(LanguageSwitcher, {
+      mocks: {
+        $route: {
+          path: '/ja-JP/documentation/foo',
+          params: { locale: 'ja-JP' },
+          query: {},
+        },
+      },
+      propsData,
+    });
+    const links = wrapper.findAllComponents(LanguageSwitcherLink);
+    expect(links.at(0).props('url')).toBeNull();
+    expect(links.at(1).props('url')).toBe('/ja-JP/documentation/foo?language=objc');
   });
 
   it('stores the preferred language when a link is clicked', async () => {

--- a/tests/unit/utils/i18n-utils.spec.js
+++ b/tests/unit/utils/i18n-utils.spec.js
@@ -8,7 +8,9 @@
  * See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 */
 
-import { localeIsValid, updateLocale, getLocaleParam } from '@/utils/i18n-utils';
+import {
+  localeIsValid, updateLocale, getLocaleParam, pathWithLocale,
+} from '@/utils/i18n-utils';
 import { updateLangTag } from 'docc-render/utils/metadata';
 
 jest.mock('theme/lang/locales.json', () => (
@@ -67,5 +69,21 @@ describe('getLocaleParam', () => {
   it('returns a params object', () => {
     expect(getLocaleParam('cn')).toEqual(params('cn'));
     expect(getLocaleParam('en')).toEqual(params(undefined));
+  });
+});
+
+describe('pathWithLocale', () => {
+  it('prefixes the path with the given locale', () => {
+    expect(pathWithLocale('documentation/foo', 'cn')).toBe('/cn/documentation/foo');
+    expect(pathWithLocale('/documentation/foo', 'cn')).toBe('/cn/documentation/foo');
+  });
+
+  it('does not prefix the default locale', () => {
+    expect(pathWithLocale('/documentation/foo', 'en')).toBe('/documentation/foo');
+  });
+
+  it('does not prefix when no/invalid locale is provided', () => {
+    expect(pathWithLocale('/documentation/foo')).toBe('/documentation/foo');
+    expect(pathWithLocale('documentation/foo', 'blah')).toBe('/documentation/foo');
   });
 });


### PR DESCRIPTION
Bug/issue #183095292, if applicable: 

## Summary

On a localized page (e.g. /ja-JP/documentation/foo), switching between Swift and Objective-C navigated to the English page instead of the localized one, dropping the locale from the URL.

The variant paths are canonical and carry no locale segment. When pushed to the router as an absolute path, Vue Router ignores params, so the optional `:locale?` route segment resolved to empty and navigation fell back to the default locale.

This PR adds a `pathWithLocale(path, locale)` helper and uses it at the three language-variant navigation entry points so they keep the current locale:

 - LanguageToggle: the nav-bar dropdown
 - LanguageSwitcher: the summary sidebar links
 - DocumentationTopic (created()): the preferred-language auto-redirect

The default locale (no URL segment) and unrecognized locales are intentionally left unprefixed. Each change ships with a regression test.

## Dependencies

NA

## Testing

Steps:
1. Go to a localized documentation page
2. Change the language variant in the UI
3. Assert that the page doesn't go to the English page instead.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
