### PR TITLE
Fix language suggestion banner to name the target locale

### DIFF
--- a/src/lang/locales/de-DE.json
+++ b/src/lang/locales/de-DE.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Auf Englisch anzeigen",
-  "continue-viewing": "Weiter auf Englisch anzeigen",
+  "view-in": "Auf Deutsch anzeigen",
+  "continue-viewing": "Weiter auf Deutsch anzeigen",
   "language": "Sprache",
   "video": {
     "title": "Video",

--- a/src/lang/locales/es-419.json
+++ b/src/lang/locales/es-419.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Ver en inglés",
-  "continue-viewing": "Seguir viendo en inglés",
+  "view-in": "Ver en español",
+  "continue-viewing": "Seguir viendo en español",
   "language": "Idioma",
   "video": {
     "title": "Video",

--- a/src/lang/locales/fr-FR.json
+++ b/src/lang/locales/fr-FR.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Afficher en anglais",
-  "continue-viewing": "Continuer à consulter en anglais",
+  "view-in": "Afficher en français",
+  "continue-viewing": "Continuer à consulter en français",
   "language": "Langue",
   "video": {
     "title": "Vidéo",

--- a/src/lang/locales/it-IT.json
+++ b/src/lang/locales/it-IT.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Visualizza in inglese",
-  "continue-viewing": "Continua in inglese",
+  "view-in": "Visualizza in italiano",
+  "continue-viewing": "Continua in italiano",
   "language": "Lingua",
   "video": {
     "title": "Video",

--- a/src/lang/locales/pt-BR.json
+++ b/src/lang/locales/pt-BR.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Ver em inglês",
-  "continue-viewing": "Continuar vendo em inglês",
+  "view-in": "Ver em português",
+  "continue-viewing": "Continuar vendo em português",
   "language": "Idioma",
   "video": {
     "title": "Vídeo",


### PR DESCRIPTION
Bug/issue #185417143, if applicable: 

## Summary

The SuggestLang banner offers to switch the reader to their preferred locale. Its label is rendered from the preferred locale's own catalog, `$i18n.messages[preferredLocale]['view-in']`, so the text is meant to appear in the language being suggested and to name that language. The `continue-viewing` string is the paired dismiss action, read via `$t('continue-viewing')` on the current locale.

Every localized catalog shipped these two strings hardcoded to "English" (translated into that language). As a result the banner offering to view the page in Italian read "Visualizza in inglese" ("View in English"), and the same mismatch affected German, Spanish, French, and Brazilian Portuguese. The label named the wrong destination language, which was misleading for the only case the banner ever renders: when the current locale differs from the preferred one.

This change updates `view-in` and `continue-viewing` in each catalog to name that catalog's own language: Italian, German, Spanish, French, and Brazilian Portuguese respectively. Each translation keeps the phrasing pattern already established in its locale ("Auf Deutsch anzeigen", "Ver en español", and so on) and preserves the correct diacritics. The en-US, ja-JP, ko-KR, and zh-CN catalogs already named their own language and are left unchanged.

## Dependencies

NA

## Testing

Steps:
1. Run docc-render against a translated doccarchived.
2. Go to a translated page, and select another language from the language picker
3. Go back to the previous language by changing the URL
4. A banner suggesting switching to your preferred language (the one you chose from the language picker) should come up
5. Assert that the strings are correct, for the text in the link and for the aria-label to close the banner.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
