### PR TITLE
Fix language suggestion banner to name the target locale

### DIFF
--- a/src/lang/locales/de-DE.json
+++ b/src/lang/locales/de-DE.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Auf Englisch anzeigen",
-  "continue-viewing": "Weiter auf Englisch anzeigen",
+  "view-in": "Auf Deutsch anzeigen",
+  "continue-viewing": "Weiter auf Deutsch anzeigen",
   "language": "Sprache",
   "video": {
     "title": "Video",

--- a/src/lang/locales/es-419.json
+++ b/src/lang/locales/es-419.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Ver en inglés",
-  "continue-viewing": "Seguir viendo en inglés",
+  "view-in": "Ver en español",
+  "continue-viewing": "Seguir viendo en español",
   "language": "Idioma",
   "video": {
     "title": "Video",

--- a/src/lang/locales/fr-FR.json
+++ b/src/lang/locales/fr-FR.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Afficher en anglais",
-  "continue-viewing": "Continuer à consulter en anglais",
+  "view-in": "Afficher en français",
+  "continue-viewing": "Continuer à consulter en français",
   "language": "Langue",
   "video": {
     "title": "Vidéo",

--- a/src/lang/locales/it-IT.json
+++ b/src/lang/locales/it-IT.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Visualizza in inglese",
-  "continue-viewing": "Continua in inglese",
+  "view-in": "Visualizza in italiano",
+  "continue-viewing": "Continua in italiano",
   "language": "Lingua",
   "video": {
     "title": "Video",

--- a/src/lang/locales/pt-BR.json
+++ b/src/lang/locales/pt-BR.json
@@ -1,6 +1,6 @@
 {
-  "view-in": "Ver em inglês",
-  "continue-viewing": "Continuar vendo em inglês",
+  "view-in": "Ver em português",
+  "continue-viewing": "Continuar vendo em português",
   "language": "Idioma",
   "video": {
     "title": "Vídeo",


### PR DESCRIPTION
**Explanation**: Fix language suggestion banner to name the target locale
**Scope**: Impacts only some translations in the localized banner
**Issue**: rdar://185417143
**Risk**: Small
**Testing**: No need for testing since the changes are only localized strings
**Reviewer**: @mportiz08
**Original PR**: https://github.com/swiftlang/swift-docc-render/pull/1030