### PR TITLE
Fix navigator losing merged-archive root on direct page load (#1024)

### DIFF
--- a/src/utils/navigatorData.js
+++ b/src/utils/navigatorData.js
@@ -190,23 +190,32 @@ export function flattenModules(modules) {
 }
 
 function extractRootModule(modules) {
-  const flattenedModules = flattenModules(modules);
+  // most of the time, it is expected that `modules` always has a single item
+  // that represents the top-level root node of the navigation tree—return it
+  // right away, since a merged-archive root's own nested member modules
+  // should never be treated as competing root candidates
+  if (modules.length === 1) return modules[0];
+
   // note: this "root" path won't always necessarily come at the beginning of
   // the URL in situations where the renderer is being hosted at some path
   // prefix
   const rootPathPattern = /(\/documentation\/[^/]+)/;
   const rootPath = window.location.pathname.match(rootPathPattern)?.[1] ?? '';
-  // most of the time, it is expected that `data` always has a single item
-  // that represents the top-level root node of the navigation tree
-  //
+  const matchesRootPath = module => module.path.toLowerCase().endsWith(rootPath.toLowerCase());
+
   // there may be rare, unexpected scenarios where multiple top-level root
-  // nodes are provide for some reason—if that happens, we would prefer the one
-  // with a path that most closely resembles the current URL path
+  // nodes are provided for some reason—if that happens, we would prefer the
+  // one with a path that most closely resembles the current URL path
+  const topLevelMatch = modules.find(matchesRootPath);
+  if (topLevelMatch) return topLevelMatch;
+
+  // otherwise, a matching root may be nested within one of the top-level
+  // modules—only fall back to searching nested modules once none of the
+  // top-level candidates themselves match, so a nested module can never
+  // outrank its own ancestor root
   //
-  // otherwise, the first provided node will be used
-  return flattenedModules.length === 1 ? flattenedModules[0] : (flattenedModules.find(module => (
-    module.path.toLowerCase().endsWith(rootPath.toLowerCase())
-  )) ?? flattenedModules[0]);
+  // if nothing matches at all, the first provided module will be used
+  return flattenModules(modules).find(matchesRootPath) ?? modules[0];
 }
 
 /**

--- a/tests/unit/utils/navigatorData.spec.js
+++ b/tests/unit/utils/navigatorData.spec.js
@@ -405,6 +405,43 @@ describe('when multiple top-level children are provided', () => {
       expect(flattenedIndex.swift.length).toBe(1);
       expect(flattenedIndex.swift[0].title).toBe(a.children[0].title);
     });
+
+    it('does not let a nested module outrank the sole top-level root (merged archive)', () => {
+      const alphaKit = {
+        type: 'module',
+        title: 'AlphaKit',
+        path: '/documentation/alphakit',
+        children: [
+          { type: 'article', title: 'AlphaArticle', path: '/documentation/alphakit/alphaarticle' },
+        ],
+      };
+      const betaKit = {
+        type: 'module',
+        title: 'BetaKit',
+        path: '/documentation/betakit',
+        children: [
+          { type: 'article', title: 'BetaArticle', path: '/documentation/betakit/betaarticle' },
+        ],
+      };
+      const packageRoot = {
+        type: 'module',
+        title: 'Spec SDK',
+        path: '/documentation/specsdk',
+        children: [alphaKit, betaKit],
+      };
+
+      // simulate a direct/hard load of a page nested under one of the
+      // member modules, which used to cause that module's own path to
+      // match instead of the package root's
+      Object.defineProperty(window, 'location', {
+        value: new URL('http://localhost/documentation/alphakit/alphaarticle'),
+      });
+
+      const flattenedIndex = flattenNavigationIndex({ swift: [packageRoot] });
+      const titles = flattenedIndex.swift.map(item => item.title);
+      expect(titles).toContain('AlphaKit');
+      expect(titles).toContain('BetaKit');
+    });
   });
 
   describe('extractTechnologyProps', () => {
@@ -434,6 +471,38 @@ describe('when multiple top-level children are provided', () => {
     it('skips empty languages', () => {
       const props = extractTechnologyProps({ occ: [], swift: [a] });
       expect(props.swift.technology).toBe(a.title);
+    });
+
+    it('does not let a nested module outrank the sole top-level root (merged archive)', () => {
+      const alphaKit = {
+        type: 'module',
+        title: 'AlphaKit',
+        path: '/documentation/alphakit',
+        children: [
+          { type: 'article', title: 'AlphaArticle', path: '/documentation/alphakit/alphaarticle' },
+        ],
+      };
+      const betaKit = {
+        type: 'module',
+        title: 'BetaKit',
+        path: '/documentation/betakit',
+        children: [
+          { type: 'article', title: 'BetaArticle', path: '/documentation/betakit/betaarticle' },
+        ],
+      };
+      const packageRoot = {
+        type: 'module',
+        title: 'Spec SDK',
+        path: '/documentation/specsdk',
+        children: [alphaKit, betaKit],
+      };
+
+      Object.defineProperty(window, 'location', {
+        value: new URL('http://localhost/documentation/alphakit/alphaarticle'),
+      });
+
+      const props = extractTechnologyProps({ swift: [packageRoot] });
+      expect(props.swift.technology).toBe('Spec SDK');
     });
   });
 });


### PR DESCRIPTION
Bug/issue #, if applicable: #1024

## Summary

On a hard/direct load of a page belonging to a member module of a merged archive (e.g. `/documentation/alphakit/`), the navigator dropped the synthesized package root and all sibling modules, showing only the module that matched the current URL. This happened because `extractRootModule` flattened the root module together with its nested module children into a single pool before matching candidates against the URL path, so a member module's own path matched and outranked its ancestor root. This PR makes `extractRootModule` return the sole top-level module immediately when only one is provided, and only fall back to searching nested descendants once no top-level candidate matches the URL, so a descendant can never outrank its own ancestor root. Users navigating directly to a member module's documentation page will now see the full merged-archive navigator, including the package root and sibling modules, matching the behavior seen when navigating from the root page.

## Dependencies

None.

## Testing

Steps:
1. Build or load a merged-archive documentation set where a package root module has multiple child modules (use se sample steps in https://github.com/swiftlang/swift-docc-render/issues/1024#issue-4883481987 or  see the fixture used in the new test spec: a `Spec SDK` root with `AlphaKit` and `BetaKit` children, each with their own article).
2. Navigate directly to a page nested under one of the member modules (e.g. `/documentation/alphakit/alphaarticle`) as a hard/first load, not a client-side navigation from the root.
3. Confirm the navigator still lists the package root and both `AlphaKit` and `BetaKit` as siblings, instead of only showing `AlphaKit`.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
