### PR TITLE
Fix missing "Deprecated"/"Beta" title tag color in translated pages

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -51,7 +51,7 @@
           <component :is="titleBreakComponent">{{ title }}</component>
           <template #after v-if="isSymbolDeprecated || isSymbolBeta">
             <small
-              :class="tagName"
+              :class="tagClass"
               :data-tag-name="tagName"
             />
           </template>
@@ -217,6 +217,11 @@ import Hierarchy from './DocumentationTopic/Hero/Hierarchy.vue';
 
 // size above which, the OnThisPage container is visible
 const ON_THIS_PAGE_CONTAINER_BREAKPOINT = 1050;
+
+const TagKinds = {
+  beta: 'beta',
+  deprecated: 'deprecated',
+};
 
 export default {
   name: 'DocumentationTopic',
@@ -573,6 +578,9 @@ export default {
     tagName() {
       return this.isSymbolDeprecated ? this.$t('aside-kind.deprecated') : this.$t('aside-kind.beta');
     },
+    tagClass: ({ isSymbolDeprecated }) => (
+      isSymbolDeprecated ? TagKinds.deprecated : TagKinds.beta
+    ),
     /**
      * Finds the page icon in the `pageImages` array
      * @param {Array} pageImages

--- a/src/components/DocumentationTopic/Hero/Title.vue
+++ b/src/components/DocumentationTopic/Hero/Title.vue
@@ -67,7 +67,7 @@ small {
     content: attr(data-tag-name);
   }
 
-  &.Beta {
+  &.beta {
     color: var(--color-badge-beta);
 
     @include prefers-dark {
@@ -75,7 +75,7 @@ small {
     }
   }
 
-  &.Deprecated {
+  &.deprecated {
     color: var(--color-badge-deprecated);
 
     @include prefers-dark {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -554,6 +554,7 @@ describe('DocumentationTopic', () => {
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).attributes('data-tag-name')).toBe('aside-kind.deprecated');
+    expect(smalls.at(0).classes()).toContain('deprecated');
 
     // only beta
     await wrapper.setProps({
@@ -563,6 +564,7 @@ describe('DocumentationTopic', () => {
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).attributes('data-tag-name')).toBe('aside-kind.beta');
+    expect(smalls.at(0).classes()).toContain('beta');
 
     // only deprecated
     await wrapper.setProps({
@@ -572,6 +574,7 @@ describe('DocumentationTopic', () => {
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).attributes('data-tag-name')).toBe('aside-kind.deprecated');
+    expect(smalls.at(0).classes()).toContain('deprecated');
   });
 
   it('renders an abstract', () => {


### PR DESCRIPTION
Bug/issue #186919363, if applicable: 

## Summary

The small tag rendered next to a symbol title in the documentation hero lost its orange (deprecated) or green (beta) color as soon as the page was rendered in any language other than English.

The tag element was rendered with the *translated* tag name used both as its text (through `data-tag-name` and `content: attr()` [1]) and as its
CSS class: <small :class="tagName" :data-tag-name="tagName" />

where `tagName` is the result of `$t('aside-kind.deprecated')` or `$t('aside-kind.beta')`. The stylesheet in `Title.vue`, however, matched the hardcoded English words `&.Deprecated` and `&.Beta`. With any other locale the rendered class became a localized string so neither selector ever matched and the tag inherited the default text color.

The presentation is now decoupled from the translation: `tagClass` returns a locale independent `deprecated`/`beta` identifier taken from the new `TagKinds` map, and it is the only value bound to `:class`.

The selectors in `Title.vue` were lowercased accordingly; the previous capitalized ones were dropped because they are scoped styles and no code path can emit those class names anymore.

[1] https://developer.mozilla.org/en-US/docs/Web/CSS/attr

## Dependencies

NA

## Testing

Steps:
1. Go to a translated documentation page that has been deprecated
2. Assert that the "Deprecated" title has the right color

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran `npm test`, and it succeeded
- [ ] Updated documentation if necessary
