### PR TITLE
[6.4] Fix missing "Deprecated"/"Beta" title tag color in translated pages

### DIFF
--- a/src/components/DocumentationTopic.vue
+++ b/src/components/DocumentationTopic.vue
@@ -51,7 +51,7 @@
           <component :is="titleBreakComponent">{{ title }}</component>
           <template #after v-if="isSymbolDeprecated || isSymbolBeta">
             <small
-              :class="tagName"
+              :class="tagClass"
               :data-tag-name="tagName"
             />
           </template>
@@ -216,6 +216,11 @@ import Hierarchy from './DocumentationTopic/Hero/Hierarchy.vue';
 
 // size above which, the OnThisPage container is visible
 const ON_THIS_PAGE_CONTAINER_BREAKPOINT = 1050;
+
+const TagKinds = {
+  beta: 'beta',
+  deprecated: 'deprecated',
+};
 
 export default {
   name: 'DocumentationTopic',
@@ -572,6 +577,9 @@ export default {
     tagName() {
       return this.isSymbolDeprecated ? this.$t('aside-kind.deprecated') : this.$t('aside-kind.beta');
     },
+    tagClass: ({ isSymbolDeprecated }) => (
+      isSymbolDeprecated ? TagKinds.deprecated : TagKinds.beta
+    ),
     /**
      * Finds the page icon in the `pageImages` array
      * @param {Array} pageImages

--- a/src/components/DocumentationTopic/Hero/Title.vue
+++ b/src/components/DocumentationTopic/Hero/Title.vue
@@ -67,7 +67,7 @@ small {
     content: attr(data-tag-name);
   }
 
-  &.Beta {
+  &.beta {
     color: var(--color-badge-beta);
 
     @include prefers-dark {
@@ -75,7 +75,7 @@ small {
     }
   }
 
-  &.Deprecated {
+  &.deprecated {
     color: var(--color-badge-deprecated);
 
     @include prefers-dark {

--- a/tests/unit/components/DocumentationTopic.spec.js
+++ b/tests/unit/components/DocumentationTopic.spec.js
@@ -554,6 +554,7 @@ describe('DocumentationTopic', () => {
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).attributes('data-tag-name')).toBe('aside-kind.deprecated');
+    expect(smalls.at(0).classes()).toContain('deprecated');
 
     // only beta
     await wrapper.setProps({
@@ -563,6 +564,7 @@ describe('DocumentationTopic', () => {
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).attributes('data-tag-name')).toBe('aside-kind.beta');
+    expect(smalls.at(0).classes()).toContain('beta');
 
     // only deprecated
     await wrapper.setProps({
@@ -572,6 +574,7 @@ describe('DocumentationTopic', () => {
     smalls = title.findAll('small');
     expect(smalls.length).toBe(1);
     expect(smalls.at(0).attributes('data-tag-name')).toBe('aside-kind.deprecated');
+    expect(smalls.at(0).classes()).toContain('deprecated');
   });
 
   it('renders an abstract', () => {


### PR DESCRIPTION
**Explanation**: Fix missing "Deprecated"/"Beta" title tag color in translated pages
**Scope**: Only "Deprecated"/"Beta" title tag color
**Issue**: rdar://186919363
**Risk**: Small, UI change
**Testing**: Updated unit tests, manually checked for regressions
**Reviewer**: @mportiz08
**Original PR**: https://github.com/swiftlang/swift-docc-render/pull/1033